### PR TITLE
Add CLAUDE guide; refocus site for Azure & production

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,177 @@
+# CLAUDE.md
+
+This file gives Claude (and any other AI assistant) the working context required to safely edit the Umplify website. The site is a Jekyll project deployed via GitHub Pages at [https://umplify.com](https://umplify.com).
+
+## What this site is
+
+Umplify is a Toronto-based AI transformation and Azure cloud platform engineering partner. The website is a marketing and lead-generation site for software-led businesses, ISVs, scale-ups, and enterprise teams in Canada and the United States.
+
+Primary visitor goals (in priority order):
+
+1. Book a free discovery call (`/contact/`).
+2. Understand the AI transformation and Azure platform service offering.
+3. Read insight content on the blog at `/blog/`.
+
+## Tech stack
+
+- **Static site generator:** Jekyll, deployed via GitHub Pages.
+- **Theme:** [`mmistakes/minimal-mistakes`](https://github.com/mmistakes/minimal-mistakes) v4.24.0 via `remote_theme` (do not vendor the theme).
+- **Markdown:** kramdown with GFM input.
+- **Plugins (must stay GitHub Pages compatible):**
+  - `jekyll-paginate`
+  - `jekyll-sitemap`
+  - `jekyll-gist`
+  - `jekyll-feed`
+  - `jekyll-include-cache`
+  - `jekyll-redirect-from`
+- **Hosting:** GitHub Pages with custom domain via `CNAME`.
+- **Analytics:** Google gtag (`G-WSEKFYVPNE`) configured in `_config.yml`.
+
+If a change requires a plugin not on the GitHub Pages allow-list, do not add it. Find another approach.
+
+## Repository layout
+
+```
+_config.yml              Site config (title, plugins, defaults, analytics)
+_data/
+  navigation.yml         Top nav order and labels
+  ui-text.yml            Theme UI strings (do not edit lightly)
+_includes/               Theme overrides and partials
+  head/custom.html       Custom head: favicon, OG tags, JSON-LD schemas
+  masthead.html          Top nav (overrides theme default)
+  footer.html, etc.
+_layouts/                Theme layouts (single, splash, home, archive, etc.)
+_pages/                  All non-blog pages (services, home, about, contact, faq)
+_posts/                  Blog articles. Filename pattern: YYYY-MM-DD-slug.md
+_sass/                   Theme SCSS overrides
+assets/
+  images/
+    revamp/              Current hero/diagram SVGs
+    splash/              Feature-row icons
+    logos/               Brand logos
+robots.txt               Allows all, points to sitemap.xml
+CNAME                    umplify.com
+```
+
+## Content authoring rules
+
+### Brand voice
+
+- **Plain, senior, production-first.** The reader is a CTO, VP Engineering, founder, or senior architect. Speak in their language.
+- **No fluff.** Every sentence either establishes credibility or drives a decision.
+- **No em dashes (—).** Use commas, periods, semicolons, parentheses, or restructure the sentence. (See `memory/feedback_no_em_dashes.md` in the user's memory.)
+- **Canadian English** spellings where they differ (e.g., "modernize" is fine, "centre" not "center" only in proper nouns; the site uses US-style "modernize/optimize").
+- **Avoid hype words:** "revolutionary", "cutting-edge", "10x", "game-changer", "transformative" without proof.
+- **Outcomes before features.** Lead with what the reader gets, then explain how.
+- **CTA ladder.** Every important page should end with at least one primary CTA (`Book a free discovery call`) and one secondary (e.g., `How we engage`, `Read the FAQ`).
+
+### Page front matter conventions
+
+Service pages should look like this:
+
+```yaml
+---
+title: "Service Name"
+permalink: /service-slug/
+layout: single
+author_profile: false
+service_schema: true        # renders Schema.org Service JSON-LD via _includes/head/custom.html
+excerpt: "One sentence used for meta description and OG/Twitter card."
+header:
+  overlay_color: "#08142C"
+  overlay_filter: "0.22"
+  overlay_image: /assets/images/revamp/hero-ai.svg   # AI pages
+  # or /assets/images/revamp/hero-cloud.svg          # platform/Azure pages
+redirect_from:              # optional, requires jekyll-redirect-from
+  - /old-url/
+---
+```
+
+Landing pages (home, ai-transformation, cloud-solutions) use `layout: splash` and feature rows. See `_pages/home.md` for the canonical pattern.
+
+### Permalinks
+
+Service pages use top-level slugs (`/agentic-workflow-design/`). Legacy URLs under `/cloud-solutions/...` are kept as `redirect_to:` stubs for SEO continuity. Do not break existing permalinks. If a page is retired, replace its content with a stub:
+
+```yaml
+---
+title: "..."
+permalink: /old/url/
+sitemap: false
+redirect_to: /new/url/
+---
+```
+
+### Internal linking
+
+Every service page should:
+
+1. Link to at least three related service pages.
+2. Link to `/contact/`.
+3. Link to `/how-we-engage/` if appropriate.
+
+Use markdown link syntax with leading slash: `[Label](/path/)`.
+
+### Images
+
+- Hero/header images live in `assets/images/revamp/`.
+- Feature row icons live in `assets/images/splash/`.
+- Always include alt text on `![alt](path)`.
+- SVG is preferred. Avoid raster heroes when an SVG exists.
+- The site `og_image` is `/assets/images/revamp/hero-ai.svg`. Some social platforms reject SVG OG images; prefer setting a page-specific `header.overlay_image` so the head template emits a usable URL.
+
+### SEO and structured data
+
+`_includes/head/custom.html` already emits:
+
+- `Organization` JSON-LD on every page.
+- `Service` JSON-LD when a page has `service_schema: true` in its front matter.
+- `FAQPage` JSON-LD on `/faq/` (kept in sync with `_pages/faq.md`).
+- `BlogPosting` JSON-LD on blog posts.
+
+If you add a new FAQ question on `_pages/faq.md`, also update the `FAQPage` JSON-LD block in `_includes/head/custom.html`. They must stay synchronized.
+
+If you add a new service page, set `service_schema: true` to get Service JSON-LD for free.
+
+### Navigation
+
+Top nav is driven by `_data/navigation.yml`. Keep the list short (target eight items or fewer). New service detail pages should be cross-linked from the relevant landing page (`/ai-transformation/` or `/cloud-solutions/`), not added to the top nav.
+
+## Blog posts
+
+Blog posts live in `_posts/` with filenames `YYYY-MM-DD-slug.md`. They are excluded from the audit process Claude runs on marketing pages. **Do not modify blog articles unless explicitly asked.** When writing new posts:
+
+- No em dashes (this is a project-wide rule, not blog-only).
+- Use the same kramdown/GFM conventions as existing posts.
+- Posts inherit `layout: single` and other defaults from `_config.yml`.
+
+## Local development
+
+```bash
+bundle install
+bundle exec jekyll serve
+# open http://127.0.0.1:4000/
+```
+
+Built output goes to `_site/`. **Never commit `_site/`.**
+
+## Things to avoid
+
+1. **Em dashes anywhere in site content.**
+2. Adding plugins outside the GitHub Pages allow-list.
+3. Editing files inside the `mmistakes/minimal-mistakes` theme directly. Override via `_includes/`, `_layouts/`, or `_sass/` instead.
+4. Changing existing permalinks without a `redirect_from:` (or `redirect_to:` stub) covering the old URL.
+5. Committing build artifacts (`_site/`, `.jekyll-cache/`, `.sass-cache/`).
+6. Hard-coding the site URL. Use `{{ site.url }}` or `| absolute_url` / `| relative_url` filters.
+
+## Useful tasks for Claude
+
+- **Add a new service page.** Copy the front matter pattern above, set `service_schema: true`, write the body, cross-link from `_pages/ai-transformation.md` or `_pages/cloud-solutions.md`, and link related pages from inside the new page.
+- **Retire a page.** Replace its content with the `redirect_to:` stub pattern shown above and verify nothing else in the repo links to it (`grep -r "/old-url/" _pages _data _includes`).
+- **Add a new FAQ question.** Edit both `_pages/faq.md` and the `FAQPage` JSON-LD block inside `_includes/head/custom.html`.
+- **Update the brand description.** Update `_config.yml` (`title`, `description`, `subtitle`) and re-check `_includes/head/custom.html` `Organization` JSON-LD if structural details change.
+- **Audit content for em dashes before commit.** `grep -rn "—" _pages _data _includes _config.yml _posts`. The result should be empty.
+
+## Contact for questions
+
+Repository owner: Arash Sabet (`arash.sabet@umplify.com`). The site reflects positioning that has been deliberately chosen; large strategic shifts (positioning, pricing language, ICP) should be confirmed before being shipped.

--- a/_config.yml
+++ b/_config.yml
@@ -11,11 +11,11 @@ minimal_mistakes_skin    : "default"
 
 # Site Settings
 locale                   : "en-US"
-title                    : "Umplify | AI Transformation and Cloud Platform Engineering"
+title                    : "Umplify | AI Transformation and Azure Cloud Platform Engineering"
 title_separator          : "|"
-subtitle                 : "Your AI and Cloud transformation partner"
+subtitle                 : "AI-ready systems. Production-grade Azure platforms."
 name                     : "Umplify Technologies Inc."
-description              : "Umplify helps businesses in the Greater Toronto Area and across Canada become AI-ready through AI transformation services, enterprise AI integration, agentic workflows, and Azure cloud platform engineering."
+description              : "Umplify is a Toronto-based AI transformation and Azure cloud platform engineering partner. We design agentic workflows, enterprise AI integrations, private knowledge systems, and production-grade Azure architecture for software-led businesses across Canada."
 url                      : "https://umplify.com"
 baseurl                  :
 repository               : "Umplify/umplify"
@@ -180,6 +180,7 @@ plugins:
   - jekyll-gist
   - jekyll-feed
   - jekyll-include-cache
+  - jekyll-redirect-from
 
 whitelist:
   - jekyll-paginate
@@ -187,6 +188,7 @@ whitelist:
   - jekyll-gist
   - jekyll-feed
   - jekyll-include-cache
+  - jekyll-redirect-from
 
 category_archive:
   type: liquid

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -3,8 +3,10 @@ main:
     url: /
   - title: "AI Transformation"
     url: /ai-transformation/
-  - title: "Cloud Platform Engineering"
+  - title: "Azure Platform"
     url: /cloud-solutions/
+  - title: "How We Engage"
+    url: /how-we-engage/
   - title: "Blog"
     url: /blog/
   - title: "FAQ"

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -25,12 +25,29 @@
   "@context": "https://schema.org",
   "@type": "Organization",
   "name": "Umplify Technologies Inc.",
+  "alternateName": "Umplify",
   "url": "{{ site.url }}",
   "logo": "{{ absolute_logo }}",
   "description": "{{ site.description | escape }}",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Toronto, Ontario, Canada"
+  },
   "areaServed": [
     {"@type": "AdministrativeArea", "name": "Greater Toronto Area"},
-    {"@type": "Country", "name": "Canada"}
+    {"@type": "Country", "name": "Canada"},
+    {"@type": "Country", "name": "United States"}
+  ],
+  "knowsAbout": [
+    "AI Transformation",
+    "Agentic Workflows",
+    "Enterprise AI Integration",
+    "Microsoft Azure",
+    "Azure OpenAI",
+    "Cloud Platform Engineering",
+    "SaaS Architecture",
+    "DevOps",
+    "Infrastructure as Code"
   ],
   "address": {
     "@type": "PostalAddress",
@@ -38,11 +55,55 @@
     "addressRegion": "ON",
     "addressCountry": "CA"
   },
+  "contactPoint": [
+    {
+      "@type": "ContactPoint",
+      "contactType": "sales",
+      "email": "sales@umplify.com",
+      "areaServed": ["CA", "US"],
+      "availableLanguage": "en"
+    },
+    {
+      "@type": "ContactPoint",
+      "contactType": "customer support",
+      "email": "support@umplify.com",
+      "areaServed": ["CA", "US"],
+      "availableLanguage": "en"
+    }
+  ],
   "sameAs": [
     "https://github.com/Umplify/umplify"
   ]
 }
 </script>
+
+{% if page.service_schema %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Service",
+  "serviceType": {{ page.title | jsonify }},
+  "name": {{ page.title | jsonify }},
+  "description": {{ seo_description | strip_html | strip_newlines | jsonify }},
+  "provider": {
+    "@type": "Organization",
+    "name": "Umplify Technologies Inc.",
+    "url": "{{ site.url }}"
+  },
+  "areaServed": [
+    {"@type": "AdministrativeArea", "name": "Greater Toronto Area"},
+    {"@type": "Country", "name": "Canada"},
+    {"@type": "Country", "name": "United States"}
+  ],
+  "audience": {
+    "@type": "BusinessAudience",
+    "audienceType": "Software-led businesses, startups, and enterprise teams"
+  },
+  "url": "{{ page.url | absolute_url }}",
+  "image": "{{ absolute_seo_image }}"
+}
+</script>
+{% endif %}
 
 {% if page.url == '/faq/' %}
 <script type="application/ld+json">
@@ -55,7 +116,7 @@
       "name": "What does it mean for a business to become AI-ready?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "An AI-ready business has the workflows, systems, knowledge access, permissions, governance, and platform architecture needed to support useful AI implementation."
+        "text": "An AI-ready business has the workflows, systems, knowledge access, permissions, governance, and platform architecture needed to support useful AI implementation in production rather than only in pilots."
       }
     },
     {
@@ -63,7 +124,15 @@
       "name": "What are agentic workflows?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Agentic workflows are business workflows where AI can retrieve information, support decisions, coordinate tasks, and interact with tools or business systems within defined controls."
+        "text": "Agentic workflows are business workflows where AI can retrieve information, support decisions, coordinate multi-step tasks, and interact with tools or business systems within defined human-in-the-loop controls."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Where does MCP-oriented integration fit?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "MCP-oriented integration matters when AI systems need structured, secure access to internal tools, data, and actions. It shapes how access layers, context handling, and system interoperability are designed for production use cases."
       }
     },
     {
@@ -71,7 +140,39 @@
       "name": "Why does cloud platform engineering still matter?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Cloud platform engineering provides the APIs, runtime reliability, observability, deployment automation, and secure operations needed to scale AI initiatives in production."
+        "text": "AI initiatives still depend on strong APIs, runtime reliability, observability, deployment automation, and secure operations. Without these foundations, most enterprise AI pilots fail to scale into production."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What kinds of companies does Umplify help?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Umplify works best with software-led businesses, startups, and enterprise teams in Toronto, the Greater Toronto Area, and across Canada that need AI transformation, application modernization, systems integration, or Azure platform engineering support."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How does an Umplify engagement typically start?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Most engagements begin with a focused discovery conversation followed by a short paid assessment (AI readiness, agentic workflow discovery, or platform architecture review). The output is a prioritized opportunity map, a delivery framing, and a clear recommendation for what to build first."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do you work with Microsoft Azure exclusively?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Our deepest expertise is in Microsoft Azure, .NET, and the Azure AI stack, including Azure OpenAI, Container Apps, Functions, API Management, and Bicep or Terraform automation. We can integrate with non-Azure systems where the architecture requires it."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How do you protect sensitive enterprise data when integrating AI?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "We design private knowledge access patterns, permission-aware retrieval, and controlled execution boundaries so AI can use internal context without compromising trust, security, or regulatory posture. Sensitive data stays inside your Azure tenant."
       }
     }
   ]

--- a/_pages/404.md
+++ b/_pages/404.md
@@ -2,14 +2,25 @@
 title: "Page Not Found"
 sitemap: false
 permalink: /404.html
-
-feature_row_left:
-  - image_path: /assets/images/splash/404.svg
-    title: Page not found!
-    excerpt: Bummer! The page you're looking for does not exist. Please try the home page as it may lead you to the page you were looking for.
-    url: /
-    btn_label: "Home"
-    btn_class: "btn--primary" 
+layout: single
+author_profile: false
+excerpt: "The page you were looking for has moved. Try one of the recommended pages below."
 ---
 
-{% include feature_row id="feature_row_left" type="left" %}
+## We could not find that page
+
+The link or address you followed does not match anything on the current Umplify site. The page may have been renamed, moved, or retired.
+
+## Where to go next
+
+- [Home](/), the best place to start
+- [AI Transformation Services](/ai-transformation/)
+- [Azure Cloud Platform Engineering Services](/cloud-solutions/)
+- [How We Engage](/how-we-engage/)
+- [About Umplify](/about/)
+- [FAQ](/faq/)
+- [Contact Umplify](/contact/)
+
+If you arrived here from an external link, please [let us know at sales@umplify.com](mailto:sales@umplify.com) so we can fix it.
+
+[Return to home](/){: .btn .btn--primary}

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -3,7 +3,7 @@ title: "About Umplify"
 permalink: /about/
 layout: single
 author_profile: false
-excerpt: "Learn about Umplify, an AI transformation and cloud platform engineering partner."
+excerpt: "Umplify is a Toronto-based AI transformation and Azure cloud platform engineering partner for software-led businesses across Canada and the United States."
 header:
   overlay_color: "#0B1F3F"
   overlay_filter: "0.2"
@@ -14,27 +14,50 @@ header:
 
 ## About Umplify
 
-Umplify is a technology company focused on **AI transformation services**, **agentic workflows**, **enterprise AI integration**, and **cloud platform engineering**. We help businesses become AI-ready by connecting strategy, architecture, and implementation.
+Umplify is a senior engineering partner for AI transformation and Azure cloud platform engineering. We help software-led businesses turn AI ambition into production-grade systems that meet real operational, security, and reliability standards.
+
+Headquartered in Toronto, we work with clients across the Greater Toronto Area, the rest of Canada, and into the United States. Our engineers and architects average over a decade of senior delivery experience in Microsoft Azure, .NET, and modern AI integration patterns.
 
 ## What makes Umplify different
 
-We combine senior engineering depth with practical business execution. Our work often spans Azure architecture, API and systems integration, application modernization, DevOps, private knowledge access, and the delivery foundations required for secure AI adoption.
+Most consulting offers either strategy or staffing. Umplify combines both inside one senior team.
+
+- **Architecture and execution under one roof.** The same engineers who frame the architecture build, integrate, and operationalize it.
+- **Azure-native depth.** Deep practitioner knowledge of Azure OpenAI, Container Apps, Functions, AKS, API Management, Service Bus, Cosmos DB, Bicep, and Terraform.
+- **AI built for production.** Governance, evaluation, observability, and rollout discipline are part of every engagement, not an afterthought.
+- **No bait and switch.** The senior people you meet in the first conversation are the people who deliver the work.
+- **Skills transfer built in.** Your team owns the result. Documentation, runbooks, and pairing are part of the engagement.
 
 ## Who we help
 
-Umplify is best suited to software-led businesses, startups, and enterprise teams that need to modernize internal systems, improve operational workflows, or launch AI-enabled capabilities with stronger technical foundations.
+Umplify is best suited to:
+
+- Software-led businesses and ISVs modernizing their product on Azure
+- Scale-ups embedding AI into core product workflows
+- Enterprise engineering teams launching agentic workflows or enterprise AI integration
+- Operations and finance leaders looking to remove process drag with AI-driven workflows
+- Founders building AI-native SaaS on Azure who need senior architectural support
 
 ## Selected client experience
 
 Some of the organizations whose development teams we have engaged with include TC Media, Royal and Sun Alliance Insurance Company of Canada (RSA), GuestLogix Inc., Munich Re Insurance, Comsense, and Manulife Insurance.
 
+## Our delivery principles
+
+1. **Production is the only success metric.** Pilots that never ship are not interesting.
+2. **Architecture before optimization.** A weak foundation cannot be tuned into a strong platform.
+3. **Security and governance are first-class.** Sensitive data stays inside your tenant.
+4. **Plain language wins.** Architectural decisions should be defensible to both engineers and the board.
+5. **Senior people, end to end.** No layered handoffs to junior staff.
+
 ## What an initial conversation looks like
 
-An initial discussion is usually focused on business goals, workflow bottlenecks, system readiness, internal tools, data access, and what would make an AI initiative or modernization effort commercially worthwhile.
+A first call usually focuses on business goals, workflow bottlenecks, system readiness, internal tools, data access, and what would make an AI initiative or modernization effort commercially worthwhile. By the end, you will have a sharper view of where to start and whether Umplify is the right partner for it.
 
 ## Explore related pages
 
 - [AI Transformation Services](/ai-transformation/)
-- [Cloud Platform Engineering Services](/cloud-solutions/)
+- [Azure Cloud Platform Engineering Services](/cloud-solutions/)
+- [How We Engage](/how-we-engage/)
 - [Frequently Asked Questions](/faq/)
 - [Contact Umplify](/contact/)

--- a/_pages/agentic-workflow-design.md
+++ b/_pages/agentic-workflow-design.md
@@ -4,7 +4,7 @@ permalink: /agentic-workflow-design/
 layout: single
 author_profile: false
 service_schema: true
-excerpt: "Agentic workflow design services in Toronto and Canada for businesses that want AI to retrieve context, coordinate tasks, support decisions, and participate in execution."
+excerpt: "Agentic workflow design services in Toronto and across Canada. Umplify designs workflows where AI retrieves context, coordinates tasks, supports decisions, and acts on business systems within human-in-the-loop controls."
 header:
   overlay_color: "#08142C"
   overlay_filter: "0.22"
@@ -15,24 +15,44 @@ header:
 
 ## Agentic workflow design services
 
-Most organizations do not need another chatbot. They need workflows where AI can retrieve context, guide decisions, coordinate steps, and work across systems inside clear control boundaries.
+Most organizations do not need another chatbot. They need workflows where AI can retrieve context, guide decisions, coordinate steps, and act across systems inside clear control boundaries.
 
-Umplify designs agentic workflows that are grounded in real business execution. That includes workflow mapping, human-in-the-loop boundaries, tool interactions, escalation points, and practical definitions of what AI should and should not do.
+Umplify designs agentic workflows that are grounded in real business execution. That includes workflow mapping, human-in-the-loop boundaries, tool interactions, escalation points, evaluation hooks, and practical definitions of what AI should and should not do.
 
 ## What this service covers
 
-- workflow decomposition and orchestration design
-- decision-support and action-support patterns
-- human review and approval boundaries
-- system and tool touchpoints
-- reliability and fallback design
+- Workflow decomposition and orchestration design
+- Decision-support and action-support patterns
+- Human review and approval boundaries
+- System and tool touchpoints (APIs, queues, identity, audit)
+- Evaluation, fallback, and reliability design
+- Reference implementation on Azure (Container Apps, Functions, Service Bus, Azure OpenAI)
+
+## What you get
+
+- An agentic workflow architecture mapped to a specific business outcome
+- Tool and integration design with auth, audit, and rate-limiting
+- Human-in-the-loop checkpoints that match your governance posture
+- An evaluation harness so quality can be measured, not assumed
+- A delivery plan with phases, dependencies, and risk areas
 
 ## Why it matters
 
 This is where AI starts becoming operationally meaningful. Instead of sitting beside the workflow, it becomes part of how the workflow is executed.
 
+## Why Umplify
+
+Senior engineers and architects with production experience integrating AI into Azure-native systems. We design for governance, observability, and rollback from day one.
+
+## Ready to scope a workflow?
+
+[Book a free discovery call](/contact/){: .btn .btn--primary .btn--large}
+[How we engage](/how-we-engage/){: .btn .btn--inverse}
+
 ## Related pages
 
 - [AI Readiness Assessment](/ai-readiness-assessment/)
 - [Enterprise AI Integration](/enterprise-ai-integration/)
+- [Private Knowledge and Secure Execution](/private-knowledge-secure-execution/)
+- [AI Governance and Productionization](/ai-governance-productionization/)
 - [Contact Umplify](/contact/)

--- a/_pages/ai-governance-productionization.md
+++ b/_pages/ai-governance-productionization.md
@@ -4,7 +4,7 @@ permalink: /ai-governance-productionization/
 layout: single
 author_profile: false
 service_schema: true
-excerpt: "AI governance and productionization services in Toronto and Canada for teams that need rollout discipline, observability, evaluation, and operational control."
+excerpt: "AI governance and productionization services in Toronto and across Canada. Umplify designs the rollout discipline, observability, evaluation, and operational control that turns AI pilots into production capabilities."
 header:
   overlay_color: "#08142C"
   overlay_filter: "0.22"
@@ -17,18 +17,42 @@ header:
 
 Many AI initiatives fail after the pilot stage because the organization never solves evaluation, ownership, observability, rollout discipline, or change management. Those are not minor details. They are the difference between an interesting concept and an operational capability.
 
-Umplify helps teams define the structures that make AI deployable in practice. That includes clearer governance models, staged rollout thinking, operational visibility, and a more disciplined path into production.
+Umplify helps teams define the structures that make AI deployable in practice. That includes clearer governance models, staged rollout thinking, evaluation harnesses, operational visibility, and a more disciplined path into production.
 
 ## What this service covers
 
-- rollout and change planning
-- evaluation and monitoring thinking
-- operational ownership and delivery discipline
-- control boundaries and risk awareness
-- transition from pilot to production
+- Rollout and change planning, including staged exposure and feature flags
+- Evaluation harnesses with offline and online quality measurement
+- Monitoring and observability for AI workloads (cost, latency, quality drift, abuse)
+- Operational ownership and on-call patterns
+- Control boundaries and risk awareness aligned to your governance posture
+- Transition from pilot to production with auditable decision records
+
+## What you get
+
+- A productionization plan tailored to the workflow you are deploying
+- An evaluation harness aligned to your domain and quality bar
+- Observability and alerting design (Application Insights, Log Analytics, dashboards)
+- Governance and risk register you can share with security and compliance
+- Documented runbooks for the operations team
+
+## Why it matters
+
+Production is the only success metric. A pilot that never ships is not a result. This service is how AI investment turns into a capability you can defend, operate, and extend.
+
+## Why Umplify
+
+We have shipped enterprise systems on Azure for two decades. Governance, evaluation, and observability are part of every engagement, not a bolted-on afterthought.
+
+## Ready to productionize?
+
+[Book a free discovery call](/contact/){: .btn .btn--primary .btn--large}
+[How we engage](/how-we-engage/){: .btn .btn--inverse}
 
 ## Related pages
 
 - [AI Transformation Services](/ai-transformation/)
 - [Private Knowledge and Secure Execution](/private-knowledge-secure-execution/)
+- [Enterprise AI Integration](/enterprise-ai-integration/)
+- [Platform Foundations for AI Integration](/platform-foundations-ai-integration/)
 - [Contact Umplify](/contact/)

--- a/_pages/ai-readiness-assessment.md
+++ b/_pages/ai-readiness-assessment.md
@@ -4,7 +4,7 @@ permalink: /ai-readiness-assessment/
 layout: single
 author_profile: false
 service_schema: true
-excerpt: "AI readiness assessment services in Toronto and Canada to identify priority use cases, delivery risks, and the organizational foundations required for enterprise AI adoption."
+excerpt: "AI readiness assessment services in Toronto and across Canada. Umplify identifies priority use cases, delivery risks, and the organizational and platform foundations required for production-grade AI adoption."
 header:
   overlay_color: "#08142C"
   overlay_filter: "0.22"
@@ -15,24 +15,44 @@ header:
 
 ## AI readiness assessment services
 
-An AI readiness assessment should do more than confirm that AI is interesting. It should tell you where the business can create measurable leverage, which workflows are realistic candidates, what systems and access constraints matter, and where delivery risk is likely to appear.
+A serious AI readiness assessment should do more than confirm that AI is interesting. It should tell you where the business can create measurable leverage, which workflows are realistic candidates, what systems and access constraints matter, and where delivery risk is likely to appear.
 
 Umplify uses this work to help organizations in Toronto, the Greater Toronto Area, and across Canada move from vague interest to a sharper operating and implementation picture. The outcome is better prioritization, stronger decision-making, and a more realistic foundation for delivery.
 
 ## What this service covers
 
-- workflow and process assessment
-- systems, APIs, and internal tool review
-- knowledge access and permissions considerations
-- governance and rollout constraints
-- opportunity prioritization and delivery framing
+- Workflow and process assessment
+- Systems, APIs, and internal tool review
+- Knowledge access and permissions considerations
+- Governance, security, and rollout constraints
+- Opportunity prioritization with delivery effort and business value framing
+- Reference architecture for an Azure-native AI integration model
+
+## What you get
+
+- A prioritized opportunity map with two to five candidate use cases
+- A delivery framing for the top one to three opportunities
+- A reference architecture for AI integration on Azure
+- A risk and constraint register with mitigation guidance
+- A clear written recommendation for what to build first
 
 ## Common outcomes
 
 Teams typically leave this phase with a clearer use-case shortlist, a better understanding of what needs to be integrated, and a stronger view of what should be piloted first versus what should wait.
 
+## Engagement format
+
+Two to four weeks, fixed-fee. Mostly remote, with optional on-site sessions in the Greater Toronto Area when it accelerates the work. The output is a written brief plus a working session with leadership and engineering.
+
+## Ready to assess?
+
+[Book a free discovery call](/contact/){: .btn .btn--primary .btn--large}
+[How we engage](/how-we-engage/){: .btn .btn--inverse}
+
 ## Related pages
 
 - [AI Transformation Services](/ai-transformation/)
 - [Agentic Workflow Design](/agentic-workflow-design/)
+- [Enterprise AI Integration](/enterprise-ai-integration/)
+- [AI Governance and Productionization](/ai-governance-productionization/)
 - [Contact Umplify](/contact/)

--- a/_pages/ai-transformation.md
+++ b/_pages/ai-transformation.md
@@ -3,6 +3,7 @@ title: "AI Transformation Services"
 permalink: /ai-transformation/
 layout: splash
 author_profile: false
+service_schema: true
 classes:
   - landing
   - wide
@@ -11,20 +12,22 @@ header:
   overlay_filter: "0.18"
   overlay_image: /assets/images/revamp/hero-ai.svg
   actions:
-    - label: "Book a Discovery Call"
+    - label: "Book a Free Discovery Call"
       url: "/contact/"
-excerpt: "AI transformation services for businesses that need agentic workflows, enterprise AI integration, private knowledge systems, and production-grade delivery."
+    - label: "How We Engage"
+      url: "/how-we-engage/"
+excerpt: "AI transformation services for software-led businesses that need agentic workflows, enterprise AI integration, private knowledge systems, and production-grade Azure delivery."
 intro:
-  - excerpt: "Umplify helps organizations move beyond generic AI experimentation into focused implementation with measurable business intent. We work across strategy, workflow design, knowledge access, systems integration, and platform engineering so AI becomes a real operating capability rather than a side initiative."
+  - excerpt: "Umplify helps organizations move beyond generic AI experimentation into focused implementation with measurable business intent. We work across strategy, workflow design, knowledge access, systems integration, and Azure platform engineering so AI becomes a real operating capability rather than a side initiative."
 feature_row:
   - image_path: /assets/images/splash/solutions.svg
     title: "AI readiness assessment"
     excerpt: >-
       Serious AI work starts with clarity. We assess workflows, internal systems, access patterns, governance realities, and business constraints to identify where AI can create measurable leverage and where it will fail without deeper preparation.
 
-      This gives leadership a sharper view of priority use cases, delivery risk, operating implications, and what the organization needs to change before scaling AI more broadly.
+      Leadership leaves with a sharper view of priority use cases, delivery risk, operating implications, and what the organization needs to change before scaling AI more broadly.
     url: /ai-readiness-assessment/
-    btn_label: "Read more..."
+    btn_label: "See assessment scope"
     btn_class: "btn--primary"
   - image_path: /assets/images/splash/event-driven.svg
     title: "Agentic workflow design"
@@ -33,16 +36,16 @@ feature_row:
 
       The outcome is a more capable operating model where AI becomes part of execution rather than a disconnected interface layered on top of work.
     url: /agentic-workflow-design/
-    btn_label: "Read more..."
+    btn_label: "Explore workflow design"
     btn_class: "btn--primary"
   - image_path: /assets/images/splash/iaac.svg
     title: "Enterprise AI integration"
     excerpt: >-
       AI becomes materially more useful when it can interact with real business systems. We design integration patterns across APIs, internal platforms, tools, and access layers so AI can operate with the right context and within the right limits.
 
-      This includes practical architecture for secure system connectivity, structured context handling, and readiness for MCP-oriented approaches where they fit the problem.
+      This includes practical architecture for secure system connectivity, structured context handling, and MCP-oriented approaches where they fit the problem.
     url: /enterprise-ai-integration/
-    btn_label: "Read more..."
+    btn_label: "See integration services"
     btn_class: "btn--primary"
 feature_row_left1:
   - image_path: /assets/images/revamp/diagram-agentic.svg
@@ -50,9 +53,9 @@ feature_row_left1:
     excerpt: >-
       Private knowledge is often the difference between superficial AI and useful AI. We help organizations structure secure retrieval, permission-aware access, and execution patterns that let AI use internal context without compromising trust or control.
 
-      This creates stronger answers, better actions, and more dependable behavior in high-value business workflows.
+      Sensitive data stays inside your Azure tenant. Access is permission-aware, audit-logged, and aligned to your existing identity model.
     url: /private-knowledge-secure-execution/
-    btn_label: "Read more..."
+    btn_label: "How we secure AI execution"
     btn_class: "btn--primary"
 feature_row_right1:
   - image_path: /assets/images/revamp/diagram-mcp.svg
@@ -60,9 +63,9 @@ feature_row_right1:
     excerpt: >-
       Many AI initiatives stall after early enthusiasm because the organization never solves governance, delivery ownership, evaluation, observability, or rollout design. We help teams close that gap.
 
-      The result is a better path from promising concept to production-ready capability, with stronger execution discipline and less strategic drift.
+      The result is a clear path from promising concept to production-ready capability, with stronger execution discipline and less strategic drift.
     url: /ai-governance-productionization/
-    btn_label: "Read more..."
+    btn_label: "See productionization services"
     btn_class: "btn--primary"
 ---
 
@@ -71,12 +74,31 @@ feature_row_right1:
 {% include feature_row id="feature_row_left1" type="left" %}
 {% include feature_row id="feature_row_right1" type="right" %}
 
+## Outcomes you can expect
+
+AI transformation engagements at Umplify are scoped around measurable shifts:
+
+- A short, defensible AI roadmap that survives leadership scrutiny
+- One to three priority use cases with delivery effort and business value framing
+- A reference architecture for secure AI integration on Azure
+- Agentic workflows running in production with human-in-the-loop controls
+- Documented governance, evaluation, and observability for AI workloads
+- A team that can extend the result without dependency on us
+
+## Why software-led businesses choose Umplify for AI
+
+- **Senior-only delivery.** Architects and engineers with production AI integration experience.
+- **Azure-native by design.** Deep practitioner knowledge of Azure OpenAI, AI Foundry, Container Apps, Functions, API Management, and Bicep or Terraform.
+- **Production-first mindset.** Governance, evaluation, and observability are part of every engagement.
+- **Engineering partnership.** Embedded delivery alongside your team, with documentation and skills transfer built in.
+
+## Who this is for
+
+Umplify works best with software-led businesses, ISVs, scale-ups, and enterprise teams that want to modernize how work gets done and need more than a generic advisory deck. We are most useful when the conversation needs to move from slideware to architecture.
+
 ## Why this page matters
 
 AI transformation is not one service. It is the coordinated redesign of workflows, systems, governance, knowledge access, and execution patterns so AI can operate in a meaningful, controlled, and commercially useful way.
 
-## Who this is for
-
-Umplify works best with software-led businesses, startups, and enterprise teams that want to modernize how work gets done and need more than a generic advisory deck.
-
-[Talk to Umplify about AI transformation](/contact/){: .btn .btn--primary}
+[Talk to Umplify about AI transformation](/contact/){: .btn .btn--primary .btn--large}
+[See how we engage](/how-we-engage/){: .btn .btn--inverse}

--- a/_pages/azure-cloud-enrollment.md
+++ b/_pages/azure-cloud-enrollment.md
@@ -1,33 +1,6 @@
 ---
 title: "Azure Cloud Enrollment"
-sitemap: false
-layout: splash
 permalink: /cloud-solutions/azure-cloud-enrollment/
-
-feature_row_left:
-  - image_path: /assets/images/splash/cloudenrollment.svg
-
-feature_row_left:
-  - image_path: /assets/images/splash/cloudenrollment.svg
-    title: Azure Cloud Enrollment
-    excerpt: Startups, Independent Software Vendors, and large enterprises are employing cloud infrastructure to make their products available 24/7, fault-tolerant, secure, and scalable as their businesses grow. This technological demand dictates modernizing applications' architecture to adapt models like Platform-as-a-Service (Paas), Software-as-a-Service (SaaS), or Infrastructure-as-a-Service (IaaS). With the evolving cloud technologies, our team has enough expertise to seamlessly steer your business through all possible challenges. We have tailored Azure Cloud Enrollment solution to help companies considering cloud adoption or are at the early stage of adopting it for their business.
+sitemap: false
+redirect_to: /cloud-modernization/
 ---
-
-{% include feature_row id="feature_row_left" type="left" %}
-
-
-## Assessment
-
-Our senior developers and architects are experts in the Microsoft Azure Cloud technology and harness its powerful platform to transform your business with cloud-native application modernization. We engage our subject-matter experts with your key team members to review and understand your business model and document your current status and ultimate goal. We also consider essential requirements in this phase, including security, application architecture, user traffic, infrastructure, DevOps, and the allocated budget.
-
-## Implementing success strategy
-
-We leverage a team of unparalleled architects and star developers at Umplify. Following the assessment phase, this team dives into analyzing the collected data and information. It discusses the requirements to develop sustainable, scalable, and modern solutions for your business. Should further consultation, idea verification, and clarification become necessary, we will reach out to seek your team's input during this phase.
-
-## Presentation
-
-We present our recommendations during a meeting to discuss our strategy for putting a sustainable infrastructure and application architecture in place. We will highlight the construction phase's necessary tools, code release and branching strategies, Azure Cloud components to utilize, associated costs, the extent of scalability and resilience, DevOps, and automation to deploy the application to multiple environments like Dev, Test, UAT, and production.
-
-## Implementation
-
-Implementing and developing cloud applications is an essential service to our clients. We will partner with your company to implement your cloud application in-house at Umplify or to extend your development team by embedding our resources into it to commence the construction phase. Should you wish to employ our strategy in cloud adoption only, the presentation phase will conclude our engagement while we are always available for further consultation and solution augmentation.

--- a/_pages/cloud-modernization.md
+++ b/_pages/cloud-modernization.md
@@ -4,11 +4,13 @@ permalink: /cloud-modernization/
 layout: single
 author_profile: false
 service_schema: true
-excerpt: "Cloud modernization services in Toronto and Canada for businesses that need stronger architecture, better resilience, and a clearer foundation for AI-ready systems."
+excerpt: "Azure cloud modernization services in Toronto and across Canada. Umplify modernizes constrained or aging applications into architectures that are scalable, resilient, and AI-ready."
 header:
   overlay_color: "#08142C"
   overlay_filter: "0.20"
   overlay_image: /assets/images/revamp/hero-cloud.svg
+redirect_from:
+  - /cloud-solutions/azure-cloud-enrollment/
 ---
 
 ![Cloud modernization visual](/assets/images/revamp/cloud-modernization.svg)
@@ -17,18 +19,42 @@ header:
 
 Cloud modernization is not simply a migration task. It is an opportunity to improve system boundaries, operational resilience, maintainability, and the ability of the platform to support future change.
 
-Umplify helps businesses redesign constrained or aging systems into architectures that are more scalable, easier to operate, and better prepared for modern integration and AI-enabled workflows.
+Umplify helps businesses redesign constrained or aging systems into architectures that are more scalable, easier to operate, and better prepared for modern integration and AI-enabled workflows. Our work is Azure-native, .NET-deep, and grounded in two decades of senior engineering experience.
 
 ## What this service covers
 
-- modernization strategy and architecture framing
-- application and service boundary review
-- resiliency and maintainability improvements
-- preparation for deeper integration and platform evolution
-- modernization planning for product and workflow growth
+- Modernization strategy and reference architecture
+- Application and service boundary review (monolith decomposition, modular monoliths, microservices)
+- Resiliency, scalability, and maintainability improvements
+- Migration planning to Azure App Service, Container Apps, AKS, or Functions
+- Data modernization (Cosmos DB, Azure SQL, PostgreSQL Flexible Server, Event Hubs)
+- Preparation for AI integration and agentic workflows
+
+## What you get
+
+- A reference architecture that fits your product, your team, and your budget
+- A staged migration plan with risk and rollback framing
+- Infrastructure-as-code (Bicep or Terraform) you can review, version, and own
+- CI/CD pipelines that make releases boring instead of risky
+- Skills transferred to your engineering team along the way
+
+## Why it matters
+
+A modernized platform is the prerequisite for almost every AI integration that ships in production. Without it, AI sits on top of fragile foundations and breaks under real-world traffic.
+
+## Why Umplify
+
+Senior architects and engineers with deep experience modernizing enterprise .NET applications onto Microsoft Azure. We design for production, not for the proof of concept.
+
+## Ready to modernize?
+
+[Book a free discovery call](/contact/){: .btn .btn--primary .btn--large}
+[How we engage](/how-we-engage/){: .btn .btn--inverse}
 
 ## Related pages
 
-- [Cloud Platform Engineering Services](/cloud-solutions/)
+- [Azure Cloud Platform Engineering Services](/cloud-solutions/)
+- [SaaS and Platform Architecture](/saas-platform-architecture/)
 - [Web Applications and APIs](/web-applications-apis/)
+- [Infrastructure as Code and DevOps](/infrastructure-as-code-devops/)
 - [Contact Umplify](/contact/)

--- a/_pages/cloud-solutions.md
+++ b/_pages/cloud-solutions.md
@@ -1,8 +1,9 @@
 ---
-title: "Cloud Platform Engineering Services"
+title: "Azure Cloud Platform Engineering Services"
 layout: splash
 permalink: /cloud-solutions/
 author_profile: false
+service_schema: true
 classes:
   - landing
   - wide
@@ -10,7 +11,12 @@ header:
   overlay_color: "#08142C"
   overlay_filter: "0.16"
   overlay_image: /assets/images/revamp/hero-cloud.svg
-excerpt: "Cloud platform engineering services for Azure, APIs, DevOps, application modernization, and AI-ready architecture."
+  actions:
+    - label: "Book a Platform Architecture Review"
+      url: "/contact/"
+    - label: "How We Engage"
+      url: "/how-we-engage/"
+excerpt: "Azure cloud platform engineering services in Toronto and across Canada for AI-ready architecture, APIs, DevOps, application modernization, SaaS evolution, and production-grade delivery."
 feature_row_right_title:
   - image_path: /assets/images/revamp/hero-cloud.svg
     title: "Cloud platform engineering for AI-ready businesses"
@@ -88,8 +94,32 @@ feature_row_right3:
 {% include feature_row id="feature_row_left3" type="left" %}
 {% include feature_row id="feature_row_right3" type="right" %}
 
+## Outcomes you can expect
+
+Azure platform engagements at Umplify are scoped around measurable shifts:
+
+- A reference architecture that fits your product, your team, and your budget
+- Modernized .NET applications and APIs ready for AI-enabled features
+- Infrastructure-as-code (Bicep or Terraform) you can review, version, and own
+- CI/CD pipelines that make releases boring instead of risky
+- Observability, cost controls, and runtime patterns that age well
+- Skills transferred to your engineering team along the way
+
+## Azure-native depth
+
+Our deepest expertise is in Microsoft Azure, .NET, and the Azure AI stack:
+
+- Azure OpenAI, Azure AI Foundry, Azure AI Search
+- Container Apps, Functions, AKS, App Service
+- API Management, Service Bus, Event Grid, Event Hubs
+- Cosmos DB, Azure SQL, PostgreSQL Flexible Server
+- Azure Front Door, CDN, Application Gateway, Private Link
+- Bicep, Terraform, Azure DevOps, GitHub Actions
+- Application Insights, Log Analytics, Azure Monitor
+
 ## Why this page matters
 
-Cloud platform engineering is the enabling layer behind reliable AI transformation. It gives businesses the architecture, integrations, delivery patterns, and runtime stability required to modernize products and support enterprise AI in production.
+Azure platform engineering is the enabling layer behind reliable AI transformation. It gives businesses the architecture, integrations, delivery patterns, and runtime stability required to modernize products and support enterprise AI in production.
 
-[Discuss your platform architecture](/contact/){: .btn .btn--primary}
+[Discuss your platform architecture](/contact/){: .btn .btn--primary .btn--large}
+[See how we engage](/how-we-engage/){: .btn .btn--inverse}

--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -3,7 +3,7 @@ title: "Contact Umplify"
 layout: single
 permalink: /contact/
 author_profile: false
-excerpt: "Contact Umplify in Toronto about AI transformation services, agentic workflows, enterprise AI integration, and cloud platform engineering across the Greater Toronto Area and Canada."
+excerpt: "Contact Umplify in Toronto for AI transformation, agentic workflows, enterprise AI integration, and Azure cloud platform engineering across Canada and the United States."
 header:
   overlay_color: "#08142C"
   overlay_filter: "0.18"
@@ -12,28 +12,52 @@ header:
 
 ![AI transformation visual](/assets/images/revamp/hero-ai.svg)
 
-## Contact Umplify
+## Talk to a senior architect, not a sales pipeline
 
-The best fit for an initial conversation is usually one of these:
+Most first calls with Umplify are with a senior architect or principal engineer. The goal of the first conversation is simple: get to a clear view of your situation, understand what you want to change, and decide together whether a deeper engagement makes sense.
 
-- AI readiness and opportunity assessment
-- agentic workflow design and operating model planning
-- enterprise AI integration across internal tools and knowledge sources
-- cloud platform engineering for scale, reliability, and delivery
-- application modernization tied to enterprise AI adoption
+The first 30-minute discovery call is free. There is no obligation to move forward.
 
-Sales email: [sales@umplify.com](mailto:sales@umplify.com)
+## Pick the starting point that fits
 
-Support email: [support@umplify.com](mailto:support@umplify.com)
+Most engagements begin with one of these:
 
-Business hours *(Toronto, ON)*: 8:30 AM - 5:00 PM (EST)
+- **AI readiness and opportunity assessment** to identify where AI can create measurable business value
+- **Agentic workflow discovery** to scope a specific workflow for AI-driven execution
+- **Enterprise AI integration review** to design secure access to internal tools and knowledge
+- **Azure platform architecture review** for AI-ready scale, reliability, and delivery
+- **Application modernization** tied to enterprise AI adoption
 
-## What to include in your message
+If you are not sure which fits, send us a few sentences about your situation and we will recommend a starting point.
 
-A strong starting message usually includes your business context, the systems involved, the workflows you want to improve, and whether you are exploring strategy, implementation, or both.
+## Reach us
+
+- **Sales and new engagements:** [sales@umplify.com](mailto:sales@umplify.com)
+- **Existing clients and support:** [support@umplify.com](mailto:support@umplify.com)
+- **Business hours (Toronto, ON):** 8:30 AM to 5:00 PM EST, Monday to Friday
+- **Typical response time:** within one business day
+
+## What to include in your first message
+
+A strong starting message usually includes:
+
+1. A short description of your business and product
+2. The systems, platforms, or workflows you want to improve
+3. Whether you are exploring strategy, implementation, or both
+4. Any timeline or budget constraints we should know about
+5. Whether you have existing Azure investments
+
+The more context you can share upfront, the more focused the first conversation becomes.
+
+## Service areas
+
+Umplify is based in Toronto, Ontario, Canada and works with clients across the Greater Toronto Area, the rest of Canada, and the United States. Engagements are remote-first, with on-site time available in the GTA when it accelerates the work.
 
 ## Helpful pages
 
 - [AI Transformation Services](/ai-transformation/)
-- [Cloud Platform Engineering Services](/cloud-solutions/)
+- [Azure Cloud Platform Engineering Services](/cloud-solutions/)
+- [How We Engage](/how-we-engage/)
 - [Frequently Asked Questions](/faq/)
+
+[Email sales@umplify.com](mailto:sales@umplify.com){: .btn .btn--primary .btn--large}

--- a/_pages/enterprise-ai-integration.md
+++ b/_pages/enterprise-ai-integration.md
@@ -4,7 +4,7 @@ permalink: /enterprise-ai-integration/
 layout: single
 author_profile: false
 service_schema: true
-excerpt: "Enterprise AI integration services in Toronto and Canada for businesses that need AI to connect to internal tools, platforms, APIs, and structured context safely."
+excerpt: "Enterprise AI integration services in Toronto and across Canada. Umplify designs the architecture that lets AI safely interact with internal tools, platforms, APIs, and structured context inside your Azure tenant."
 header:
   overlay_color: "#08142C"
   overlay_filter: "0.22"
@@ -15,24 +15,45 @@ header:
 
 ## Enterprise AI integration services
 
-Enterprise AI becomes significantly more useful when it can interact with real systems, real tools, and real business context. That requires more than one-off connectors. It requires architecture that handles permissions, access boundaries, structured context, API design, and operational reliability.
+Enterprise AI becomes significantly more useful when it can interact with real systems, real tools, and real business context. That requires more than one-off connectors. It requires architecture that handles permissions, access boundaries, structured context, API design, observability, and operational reliability.
 
-Umplify helps organizations create those integration layers so AI can participate in meaningful work without compromising control. This includes practical architecture for modern internal tooling, context delivery, and MCP-oriented approaches where they fit the problem.
+Umplify helps organizations create those integration layers so AI can participate in meaningful work without compromising control. This includes practical architecture for modern internal tooling, context delivery, MCP-oriented patterns, and Azure-native security and identity.
 
 ## What this service covers
 
-- internal system and API integration design
-- access-layer and permission-aware context patterns
-- tool connectivity for AI workflows
-- architectural readiness for structured context exchange
-- delivery framing for production use cases
+- Internal system and API integration design
+- Access-layer and permission-aware context patterns
+- Tool connectivity for AI workflows (CRM, ERP, ticketing, knowledge bases, line-of-business apps)
+- MCP-oriented architecture where it fits the problem
+- Identity, audit, and rate-limiting design
+- Observability and evaluation hooks across the integration surface
+- Delivery framing for production use cases
+
+## What you get
+
+- An integration architecture aligned to your current Azure tenant and identity model
+- A prioritized list of high-value tool integrations
+- API and access-layer design with auth, audit, and rate-limiting
+- Reference implementation patterns on Azure (API Management, Functions, Container Apps, Entra ID)
+- Operational runbooks and observability design
 
 ## Why it matters
 
-Without integration, most AI initiatives remain informational. With the right integration model, they start becoming operational.
+Without integration, most AI initiatives remain informational. With the right integration model, they start becoming operational and create measurable business leverage.
+
+## Why Umplify
+
+Two decades of senior software engineering depth, focused on .NET and Microsoft Azure. Our integration patterns are designed for production: identity-bound access, audit logging, observability, and disciplined rollback.
+
+## Ready to design your integration layer?
+
+[Book a free discovery call](/contact/){: .btn .btn--primary .btn--large}
+[How we engage](/how-we-engage/){: .btn .btn--inverse}
 
 ## Related pages
 
 - [Private Knowledge and Secure Execution](/private-knowledge-secure-execution/)
 - [Platform Foundations for AI Integration](/platform-foundations-ai-integration/)
+- [Agentic Workflow Design](/agentic-workflow-design/)
+- [AI Transformation Services](/ai-transformation/)
 - [Contact Umplify](/contact/)

--- a/_pages/faq.md
+++ b/_pages/faq.md
@@ -1,9 +1,9 @@
 ---
-title: "AI Transformation FAQ"
+title: "AI Transformation and Azure Engineering FAQ"
 permalink: /faq/
 layout: single
 author_profile: false
-excerpt: "Frequently asked questions about AI transformation consulting, agentic workflows, enterprise AI integration, and cloud platform engineering in Toronto and Canada."
+excerpt: "Frequently asked questions about AI transformation, agentic workflows, enterprise AI integration, and Azure cloud platform engineering with Umplify in Toronto and across Canada."
 header:
   overlay_color: "#0B1F3F"
   overlay_filter: "0.16"
@@ -14,27 +14,60 @@ header:
 
 ### What does it mean for a business to become AI-ready?
 
-An AI-ready business has the right combination of workflows, systems, knowledge access, permissions, governance, and platform architecture to support useful AI implementation. That usually includes clean integration paths, secure access to internal context, and clear operational goals.
+An AI-ready business has the right combination of workflows, systems, knowledge access, permissions, governance, and platform architecture to support useful AI implementation in production rather than only in pilots. That usually includes clean integration paths, secure access to internal context, evaluation discipline, and clear operational goals.
 
 ### What are agentic workflows?
 
-Agentic workflows are business workflows where AI can do more than answer prompts. They allow AI systems to retrieve information, support decisions, coordinate tasks, and interact with tools or business systems within defined controls.
+Agentic workflows are business workflows where AI does more than answer prompts. AI systems retrieve information, support decisions, coordinate multi-step tasks, and interact with tools or business systems within defined human-in-the-loop controls. The aim is for AI to participate in execution, not sit beside it.
 
 ### Where does MCP-oriented integration fit?
 
-MCP-oriented integration is relevant when a business wants modern AI systems to access internal tools, data, and actions in a more structured way. In practice, that means designing secure access layers, context handling, and system interoperability that support AI use cases.
+Model Context Protocol (MCP) oriented integration is relevant when a business wants modern AI systems to access internal tools, data, and actions in a structured, auditable way. In practice, that means designing secure access layers, context handling, and system interoperability that support AI use cases without sprawling one-off connectors.
 
 ### Why does cloud platform engineering still matter?
 
-Cloud platform engineering remains essential because AI initiatives still depend on strong architecture, APIs, runtime reliability, observability, deployment automation, and secure operations. Without those foundations, AI pilots often fail to scale.
+AI initiatives still depend on strong architecture, APIs, runtime reliability, observability, deployment automation, and secure operations. Without those foundations, most AI pilots fail to scale into production. Platform engineering is where AI initiatives become dependable enterprise capabilities.
 
 ### What kinds of companies does Umplify help?
 
-Umplify is best suited to software-led businesses, startups, and enterprise teams in Toronto, the Greater Toronto Area, and across Canada that need AI transformation consulting, application modernization, systems integration, or platform engineering support.
+Umplify is best suited to software-led businesses, ISVs, scale-ups, and enterprise teams in Toronto, the Greater Toronto Area, and across Canada that need AI transformation, application modernization, systems integration, or Azure platform engineering support. We are most useful when the conversation needs to move from slideware to architecture.
+
+### How does an Umplify engagement typically start?
+
+Most engagements begin with a free 30-minute discovery call followed by a short paid assessment, usually one of: AI readiness assessment, agentic workflow discovery, or platform architecture review. The output is a prioritized opportunity map, a delivery framing, and a clear recommendation for what to build first. From there, we either deliver the work, advise your team, or both.
+
+### How long does an engagement run?
+
+Assessments are typically two to four weeks. Implementation engagements are usually scoped in eight to twelve week increments tied to a specific outcome (a workflow shipped, a platform component delivered, an integration in production). We avoid open-ended retainers because they obscure outcomes.
+
+### What does a typical engagement cost?
+
+Pricing depends on scope, but assessments are fixed-fee and implementation work is fixed-fee per increment wherever possible. We share a written proposal with a clear scope, deliverables, assumptions, and pricing before any contract is signed. There are no hidden change-order traps.
+
+### Do you work with Microsoft Azure exclusively?
+
+Our deepest expertise is in Microsoft Azure, .NET, and the Azure AI stack, including Azure OpenAI, Azure AI Foundry, Container Apps, Functions, API Management, AKS, Cosmos DB, Service Bus, and Bicep or Terraform automation. We can integrate with non-Azure systems where the architecture requires it, but our recommendations will favor Azure-native patterns.
+
+### How do you protect sensitive enterprise data when integrating AI?
+
+We design private knowledge access patterns, permission-aware retrieval, and controlled execution boundaries so AI can use internal context without compromising trust, security, or regulatory posture. Sensitive data stays inside your Azure tenant. We support patterns like Azure Private Link, customer-managed keys, network isolation, identity-bound access, and audit logging by default.
+
+### Will you embed with our team or work as a separate vendor?
+
+Both models work. Many engagements use an embedded model where Umplify architects and engineers pair with your team, contribute to your repos, attend your standups, and transfer skills as we go. Others run as a separate workstream with regular delivery checkpoints. We pick the model that fits the work, not the other way around.
+
+### Do you replace our existing development team?
+
+No. We strengthen and extend your team. The point of the engagement is to leave your team with sharper architecture, stronger delivery patterns, and the ability to own and evolve the result.
+
+### What outputs do we keep at the end of an engagement?
+
+Code in your repositories, infrastructure-as-code in your tooling, documentation in your knowledge base, runbooks in your operations system, and the architectural reasoning behind every major decision. There is no Umplify-only black box.
 
 ### Which page should I read next?
 
 - [AI Transformation](/ai-transformation/)
-- [Cloud Platform Engineering](/cloud-solutions/)
+- [Azure Cloud Platform Engineering](/cloud-solutions/)
+- [How We Engage](/how-we-engage/)
 - [About Umplify](/about/)
 - [Contact Umplify](/contact/)

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -1,6 +1,6 @@
 ---
 permalink: /
-title: "AI Transformation Services for Real Business Change"
+title: "AI Transformation and Azure Platform Engineering for Software-Led Businesses"
 author_profile: false
 layout: splash
 classes:
@@ -11,60 +11,60 @@ header:
   overlay_filter: "0.18"
   overlay_image: /assets/images/revamp/hero-ai.svg
   actions:
+    - label: "Book a Free 30-min Discovery Call"
+      url: "/contact/"
     - label: "Explore AI Transformation"
       url: "/ai-transformation/"
-    - label: "Book a Discovery Call"
-      url: "/contact/"
-excerpt: "Umplify helps businesses become AI-ready through AI transformation services, agentic workflows, enterprise AI integration, and cloud platform engineering."
+excerpt: "Umplify helps software-led businesses move from scattered AI experiments to production-ready agentic workflows, enterprise AI integrations, and Azure platforms that actually scale."
 intro:
-  - excerpt: "Umplify helps ambitious businesses move from scattered AI experiments to production-ready systems that create measurable operational leverage. We design AI-ready workflows, enterprise integrations, private knowledge access, and the platform foundations required to scale with confidence."
+  - excerpt: "Most AI pilots stall before they create real business value. Umplify is the senior engineering partner that takes ambitious organizations from discovery to production. We design AI-ready workflows, secure enterprise integrations, private knowledge systems, and the Azure platform foundations required to scale safely. The result is measurable operational leverage, not another deck."
 feature_row:
   - image_path: /assets/images/splash/solutions.svg
     title: "AI Transformation"
     excerpt: >-
-      Build a practical path from opportunity discovery to implementation. We help leadership teams and technical teams align on where AI can create measurable business value, what has to change operationally, and what must be built technically.
+      Build a practical path from opportunity discovery to production. We align leadership and engineering on where AI creates measurable business value, what has to change operationally, and what must be built technically.
 
-      The result is a clearer strategy, a stronger delivery roadmap, and a more disciplined foundation for enterprise AI adoption.
+      You leave with a prioritized roadmap, a delivery framing, and a stronger foundation for enterprise AI adoption.
     url: /ai-transformation/
-    btn_label: "Read more..."
+    btn_label: "See AI services"
     btn_class: "btn--primary"
   - image_path: /assets/images/splash/event-driven.svg
     title: "Agentic Workflows"
     excerpt: >-
-      Move beyond assistants that only answer questions. We design workflows where AI can retrieve context, coordinate steps, support decisions, and interact with business systems within clear control boundaries.
+      Move beyond chatbots that only answer questions. We design workflows where AI retrieves the right context, coordinates steps, supports decisions, and acts on business systems inside clear human-in-the-loop controls.
 
-      This creates faster execution, lower operational drag, and a more useful role for AI inside real day-to-day work.
+      The outcome is faster execution, lower operational drag, and AI that participates in real day-to-day work.
     url: /agentic-workflow-design/
-    btn_label: "Read more..."
+    btn_label: "Explore agentic workflows"
     btn_class: "btn--primary"
   - image_path: /assets/images/splash/iaac.svg
-    title: "Cloud Platform Engineering"
+    title: "Azure Platform Engineering"
     excerpt: >-
-      Give your AI initiatives an architecture they can rely on. We design Azure-based platforms, APIs, delivery pipelines, runtime controls, and observability patterns that make modern systems dependable in production.
+      Give your AI initiatives an architecture they can rely on. We design Azure-based platforms, APIs, delivery pipelines, runtime controls, and observability so modern systems stay dependable in production.
 
-      The goal is not just scale. It is safe scale, stronger operations, and a platform built for product and workflow growth.
+      The goal is safe scale, stronger operations, and a platform built for product growth and AI-enabled workflows.
     url: /cloud-solutions/
-    btn_label: "Read more..."
+    btn_label: "See platform services"
     btn_class: "btn--primary"
 feature_row_right1:
   - image_path: /assets/images/revamp/diagram-agentic.svg
     title: "Private knowledge and secure execution"
     excerpt: >-
-      AI becomes far more valuable when it can work with the right internal context. We help organizations structure secure retrieval, permissions-aware knowledge access, and execution patterns that respect operational and governance boundaries.
+      AI becomes far more valuable when it can use the right internal context. We help organizations structure secure retrieval, permission-aware knowledge access, and execution patterns that respect operational and governance boundaries.
 
-      That means better answers, better actions, and less risk when AI starts interacting with real business content and systems.
+      That means better answers, better actions, and less risk when AI starts interacting with real business content and systems. Sensitive data stays inside your Azure tenant.
     url: /private-knowledge-secure-execution/
-    btn_label: "Read more..."
+    btn_label: "How we secure AI execution"
     btn_class: "btn--primary"
 feature_row_left1:
   - image_path: /assets/images/revamp/diagram-mcp.svg
     title: "Enterprise AI integration"
     excerpt: >-
-      Strong AI initiatives depend on strong integration. We connect tools, internal platforms, knowledge sources, APIs, and access layers so AI systems can operate with the right context and within the right boundaries.
+      Strong AI initiatives depend on strong integration. We connect tools, internal platforms, knowledge sources, APIs, and access layers so AI systems can operate with the right context and within the right boundaries, including MCP-oriented patterns where they fit.
 
-      This is where strategy becomes usable infrastructure and where isolated AI ideas start becoming enterprise capability.
+      This is where strategy becomes usable infrastructure, and where isolated AI ideas turn into enterprise capability.
     url: /enterprise-ai-integration/
-    btn_label: "Read more..."
+    btn_label: "Explore integration services"
     btn_class: "btn--primary"
 ---
 
@@ -73,16 +73,43 @@ feature_row_left1:
 {% include feature_row id="feature_row_right1" type="right" %}
 {% include feature_row id="feature_row_left1" type="left" %}
 
-## AI-ready systems for real operational leverage
+## Outcomes our clients ask us to deliver
 
-Umplify helps companies modernize systems for AI, connect internal tools and knowledge to modern models, and implement workflows that improve how work gets done. Our work spans **AI transformation services**, **agentic workflow design**, **enterprise AI integration**, **private knowledge systems**, and **cloud platform engineering**.
+Umplify engagements are scoped around measurable shifts, not abstract advice. Typical outcomes include:
+
+- A short, defensible AI roadmap that survives leadership scrutiny
+- Agentic workflows running in production with human-in-the-loop controls
+- Secure access to private knowledge across SharePoint, Confluence, OneDrive, and internal APIs
+- An Azure platform that supports AI workloads with predictable cost and SLAs
+- Modernized .NET applications, APIs, and delivery pipelines ready for AI-enabled features
+- Documented governance, evaluation, and observability for AI in production
+
+## Why software-led businesses choose Umplify
+
+Two decades of senior software engineering depth, focused on Microsoft Azure, .NET, and the Azure AI stack. We work alongside your team rather than around it, so the architecture, code, and operating model you keep are ones you can extend.
+
+- **Senior-only delivery.** Architects and engineers who have shipped enterprise systems, not junior staff billed at senior rates.
+- **Azure-native by design.** Deep expertise in Azure OpenAI, Container Apps, Functions, API Management, AKS, Bicep, and Terraform.
+- **Production-first mindset.** We solve governance, evaluation, and observability before they become incidents.
+- **Engineering partnership.** Embedded delivery alongside your team, with documentation and skills transfer built in.
+
+## Selected client experience
+
+Some of the development teams we have engaged with include TC Media, Royal and Sun Alliance Insurance Company of Canada (RSA), GuestLogix Inc., Munich Re Insurance, Comsense, and Manulife Insurance.
 
 ## Ideal fit
 
-Umplify is best suited to software-led businesses, startups, and enterprise teams that already have valuable systems, data, and workflows but need a practical path to AI adoption and production execution.
+Umplify is best suited to software-led businesses, ISVs, scale-ups, and enterprise engineering teams that already have valuable systems, data, and workflows but need a practical path to AI adoption and production execution. We are most useful when the conversation needs to move from slideware to architecture.
 
 ## Start with the right conversation
 
-The strongest first step is usually an **AI readiness discussion**, an **agentic workflow discovery session**, or a **platform architecture review**.
+Most engagements begin with one of three focused starting points:
 
-[Book a discovery call](/contact/){: .btn .btn--primary}
+1. **AI readiness and opportunity assessment**, when leadership wants a prioritized view of where AI can create measurable value.
+2. **Agentic workflow discovery session**, when a specific workflow is a candidate for AI-driven execution.
+3. **Platform architecture review**, when the cloud or .NET foundation needs to be ready for AI integration.
+
+The first conversation is free and takes 30 minutes. You leave with a clearer view of what to do next, regardless of whether we work together.
+
+[Book a free discovery call](/contact/){: .btn .btn--primary .btn--large}
+[Read the FAQ](/faq/){: .btn .btn--inverse}

--- a/_pages/how-we-engage.md
+++ b/_pages/how-we-engage.md
@@ -1,0 +1,99 @@
+---
+title: "How We Engage"
+permalink: /how-we-engage/
+layout: single
+author_profile: false
+excerpt: "How Umplify engages with clients on AI transformation, agentic workflows, enterprise AI integration, and Azure cloud platform engineering: discovery, assessment, delivery, and skills transfer."
+header:
+  overlay_color: "#08142C"
+  overlay_filter: "0.18"
+  overlay_image: /assets/images/revamp/hero-cloud.svg
+---
+
+![Engagement model visual](/assets/images/revamp/devops-pipeline.svg)
+
+## How Umplify engages
+
+Most consulting engagements fail one of three ways: they generate decks no one builds, they deliver code no one can operate, or they replace one set of dependencies with another. Umplify is structured to avoid all three.
+
+Every engagement runs through four phases. They are deliberately small, fixed in scope, and designed so you can stop after any phase with a usable result.
+
+## Phase 1: Discovery (free, 30 minutes)
+
+The first conversation is a 30-minute working call. We discuss your business goals, current systems, the workflows you want to improve, and the constraints that matter (compliance, timeline, budget, team capacity). At the end, you have a clearer view of what to do next, regardless of whether you choose to engage Umplify.
+
+What you leave with:
+
+- A working hypothesis on the highest-value starting point
+- A recommendation for the right type of assessment, if any
+- A direct answer on whether we are a good fit for the problem
+
+## Phase 2: Assessment (fixed-fee, two to four weeks)
+
+If a deeper engagement makes sense, we run a focused, fixed-fee assessment. Common assessment types include:
+
+- **AI readiness and opportunity assessment**, when leadership wants a prioritized view of where AI can create measurable business value
+- **Agentic workflow discovery**, when a specific workflow is a candidate for AI-driven execution
+- **Enterprise AI integration review**, when AI needs structured access to internal tools and knowledge
+- **Azure platform architecture review**, when the cloud foundation needs to be ready for AI workloads
+- **Application modernization assessment**, when a .NET or web application needs to evolve before AI is layered on top
+
+What you leave with:
+
+- A prioritized opportunity map with delivery effort and business value framing
+- A reference architecture and integration design
+- A delivery plan with phases, dependencies, and risk areas
+- A written recommendation for what to build first
+- Clear pricing for any subsequent delivery work
+
+You can stop here and execute the plan with your own team. Many clients do, and we are happy when they do.
+
+## Phase 3: Delivery (fixed-fee per increment, eight to twelve weeks)
+
+When you choose to move forward, delivery runs in eight to twelve week increments tied to a specific outcome: a workflow shipped to production, a platform component delivered, an integration live, a modernization milestone hit. Each increment is fixed-fee with documented scope, deliverables, and assumptions.
+
+Delivery typically includes:
+
+- Architecture, code, and infrastructure-as-code in your repositories
+- Pairing and skills transfer with your team
+- Tests, observability, and runbooks built in from day one
+- Governance, evaluation, and rollout discipline for AI workloads
+- Documented decisions so the result can be defended and extended
+
+We avoid open-ended retainers because they obscure outcomes. Every increment ends with something demonstrable in production.
+
+## Phase 4: Embed or step back
+
+At the end of each delivery increment, we make an honest call together: continue, slow down, or step back. Many clients keep us engaged for the next increment. Others move into a lighter advisory cadence. Both are valid outcomes. The point is that you are never locked into more than the next increment.
+
+## What stays with you
+
+When the engagement ends, you keep:
+
+- All code in your repositories
+- All infrastructure-as-code in your tooling
+- All documentation in your knowledge base
+- All runbooks in your operations system
+- The architectural reasoning behind every major decision
+
+There is no Umplify-only black box. Your team owns the result.
+
+## Engagement principles
+
+1. **Senior people, end to end.** Architects and engineers with real production experience, not junior staff billed at senior rates.
+2. **Fixed-fee where possible.** Pricing surprises kill trust. We scope tightly and price clearly.
+3. **Production is the only success metric.** Pilots that never ship are not interesting.
+4. **Skills transfer is the deliverable.** Your team should be stronger when we leave than when we arrived.
+5. **Plain language wins.** Architectural decisions should be defensible to both engineers and the board.
+
+## Ready to start?
+
+[Book a free discovery call](/contact/){: .btn .btn--primary .btn--large}
+[Read the FAQ](/faq/){: .btn .btn--inverse}
+
+## Related pages
+
+- [AI Transformation Services](/ai-transformation/)
+- [Azure Cloud Platform Engineering Services](/cloud-solutions/)
+- [About Umplify](/about/)
+- [Frequently Asked Questions](/faq/)

--- a/_pages/infrastructure-as-code-devops.md
+++ b/_pages/infrastructure-as-code-devops.md
@@ -4,11 +4,13 @@ permalink: /infrastructure-as-code-devops/
 layout: single
 author_profile: false
 service_schema: true
-excerpt: "Infrastructure as Code and DevOps services in Toronto and Canada for teams that need stronger delivery discipline, safer releases, and better operational repeatability."
+excerpt: "Infrastructure as Code and DevOps services in Toronto and across Canada. Umplify implements Azure-native provisioning automation, CI/CD, and environment consistency so releases get safer and faster."
 header:
   overlay_color: "#08142C"
   overlay_filter: "0.20"
   overlay_image: /assets/images/revamp/hero-cloud.svg
+redirect_from:
+  - /cloud-solutions/infrastructure-provisioning/
 ---
 
 ![DevOps visual](/assets/images/revamp/devops-pipeline.svg)
@@ -21,14 +23,37 @@ This improves release confidence, reduces operational variability, and gives the
 
 ## What this service covers
 
-- infrastructure automation direction
-- CI/CD and release discipline
-- environment consistency thinking
-- operational repeatability improvements
-- delivery maturity support
+- Infrastructure-as-code with Bicep or Terraform
+- Azure DevOps and GitHub Actions pipelines
+- Environment consistency across dev, test, UAT, and production
+- Release strategies (blue-green, canary, feature flags)
+- Secrets and identity management with Key Vault and Entra ID
+- Observability and audit baked into the deployment pipeline
+
+## What you get
+
+- A reusable IaC structure your team can extend
+- Pipelines that make releases boring instead of risky
+- Environment parity that eliminates "works on dev" surprises
+- Documented deployment runbooks
+- Skills transferred to your engineering and platform teams
+
+## Why it matters
+
+Almost every AI integration depends on a delivery pipeline that can ship safely. Without it, AI workloads inherit the worst delivery habits of the platform underneath them.
+
+## Why Umplify
+
+Senior DevOps engineers and architects with production experience automating Azure delivery for enterprise and ISV teams.
+
+## Ready to harden your delivery?
+
+[Book a free discovery call](/contact/){: .btn .btn--primary .btn--large}
+[How we engage](/how-we-engage/){: .btn .btn--inverse}
 
 ## Related pages
 
 - [SaaS and Platform Architecture Services](/saas-platform-architecture/)
-- [Cloud Platform Engineering Services](/cloud-solutions/)
+- [Azure Cloud Platform Engineering Services](/cloud-solutions/)
+- [Platform Foundations for AI Integration](/platform-foundations-ai-integration/)
 - [Contact Umplify](/contact/)

--- a/_pages/infrastructure-provisioning.md
+++ b/_pages/infrastructure-provisioning.md
@@ -1,30 +1,6 @@
 ---
 title: "Infrastructure Provisioning"
-sitemap: false
-layout: splash
 permalink: /cloud-solutions/infrastructure-provisioning/
-
-feature_row_left:
-  - image_path: /assets/images/splash/iaac.svg
-    title: Infrastructure Provisioning
-    excerpt: Startups, Independent Software Vendors, and large enterprises are employing cloud infrastructure to make their products available 24/7, fault-tolerant, secure, and scalable as their businesses grow. This technological demand dictates modernizing applications' architecture to adapt models like Platform-as-a-Service (Paas), Software-as-a-Service (SaaS), or Infrastructure-as-a-Service (IaaS). With the evolving cloud technologies, our team has enough expertise to seamlessly steer your business through all possible challenges. We have tailored this solution to help companies considering provisioning their Azure Cloud application's infrastructure by code. 
+sitemap: false
+redirect_to: /infrastructure-as-code-devops/
 ---
-
-{% include feature_row id="feature_row_left" type="left" %}
-
-
-## Assessment
-
-Our senior developers, DevOps engineers, and architects are experts in the Microsoft Azure Cloud technology and harness its powerful platform to transform your business with cloud-native application modernization. Our architects and DevOps engineers will engage with your software team to understand the architectural components of your application hosted on Azure Cloud.
-
-## Implementing success strategy
-
-Once our DevOps engineers process the necessary information collected during the assessment phase, they will implement a set of Terraform or bicep scripts to provision your application's infrastructure on the cloud. They will ensure that they can add, remove or update the cloud resources by the implemented scripts only. Developing such scripts will take place in Umplify's Azure Cloud subscription.
-
-## Presentation
-
-We will arrange a demo session to show you how the implemented Terraform or Bicep script provisions your application's infrastructure on the cloud. We will also show you how to invoke the scripts from the Azure DevOps pipeline, command line, or even a template spec where applicable.
-
-## Implementation
-
-Implementing and developing cloud applications is our critical service to our clients. We will partner with your company to implement your cloud application in-house at Umplify or to extend your development team by embedding our resources into it to commence the construction phase. Should you wish to employ our strategy in cloud adoption, the presentation phase will conclude our engagement while we are always available for further consultation and solution augmentation.

--- a/_pages/our-mission.md
+++ b/_pages/our-mission.md
@@ -1,27 +1,44 @@
 ---
-title: "Our mission"
-sitemap: false
-layout: splash
+title: "Our Mission"
 permalink: /our-mission/
-
-feature_row_left:
-  - image_path: /assets/images/splash/404.svg
+layout: single
+author_profile: false
+sitemap: true
+excerpt: "Umplify exists to help software-led businesses turn AI ambition into production-grade, secure, and operationally sound systems on Microsoft Azure."
+header:
+  overlay_color: "#08142C"
+  overlay_filter: "0.18"
+  overlay_image: /assets/images/revamp/hero-cloud.svg
 ---
 
-{% include feature_row id="feature_row_left" type="left" %}
+![Mission visual](/assets/images/revamp/ai-platform-foundation.svg)
 
-# Our Mission
+## Our mission
 
-With senior skilled cloud architects and developers with extensive R&D backgrounds on board, we are fully equipped to help you develop cloud-native applications or migrate your existing ones to the Microsoft Azure Cloud.
+Umplify exists to help software-led businesses turn AI ambition into production-grade systems that are secure, observable, and operationally sound. We believe AI transformation only matters when it ships, runs reliably, and creates measurable business leverage.
 
-From cloud readiness assessment and strategy development to infrastructure setup, architecture redesign, migration, and maintenance, our unparalleled specialists will support you at any stage of your cloud journey. We help you deliver solutions faster with higher quality using the most cutting-edge technologies to help you automate the process of cloud software development.
+## What we believe
 
-We set up innovative and collaborative tools like code repository, automatic Continuous Integration & Continuous Delivery (CI/CD) pipelines, DevOps, Infrastructure-as-a-Code (IaaC), and automated QA testing to help your software development team perform at scale.
+1. **Production is the only success metric.** Pilots that never ship are not real outcomes.
+2. **Architecture before optimization.** A weak foundation cannot be tuned into a strong platform.
+3. **Senior people, end to end.** Architecture, code, integration, and operations should be done by people with real production experience.
+4. **Skills transfer is the deliverable.** The team you keep should be stronger because we were there.
+5. **Plain language wins.** Architectural decisions should be defensible to engineers and to the board.
 
-## An Integrated Cloud Application Development Team
+## What we do
 
-Our consulting services concept is based on total engagement; we do not just advise and then walk away. We are not just another software development shop. Our team consists of experts in all aspects of the software development lifecycle. We are known for our deep experience in Microsoft Azure Cloud and for employing .NET technology to help your development team turn the ideas into a product on the cloud. Our people become integral to your organization's team, building your cloud-powered applications efficiently and reliably using the most modern tools.
+We help organizations design AI-ready workflows, secure enterprise integrations, private knowledge systems, and Azure cloud platforms that can carry AI workloads in production. Our delivery covers strategy, architecture, hands-on engineering, governance, and operationalization, all under one senior team.
 
-With our 20+ years of experience in the software industry, we choose the most cost-effective, innovative, and efficient contemporary solution for implementing your cloud products. Some of these solutions are using NoSQL databases, event-driven serverless microservices, orchestration with Kubernetes, monitoring, cost management, and techniques to help you be more productive and agile.
+With more than two decades of senior software engineering experience, we choose the most cost-effective, modern, and maintainable solution for the situation in front of us. That often involves Azure-native services, event-driven architecture, container orchestration with AKS or Container Apps, NoSQL data, infrastructure-as-code, automated CI/CD, and disciplined observability.
 
-Our team consists of people who work with your company to navigate through all challenges, adopt changes quickly and deliver real value to your business and your clients faster with better quality.
+## Who we serve
+
+Software-led businesses, ISVs, scale-ups, and enterprise engineering teams across the Greater Toronto Area, the rest of Canada, and the United States, who want a senior partner that integrates with their team rather than around it.
+
+## Explore further
+
+- [About Umplify](/about/)
+- [How We Engage](/how-we-engage/)
+- [AI Transformation Services](/ai-transformation/)
+- [Azure Cloud Platform Engineering Services](/cloud-solutions/)
+- [Contact Umplify](/contact/)

--- a/_pages/platform-foundations-ai-integration.md
+++ b/_pages/platform-foundations-ai-integration.md
@@ -4,7 +4,7 @@ permalink: /platform-foundations-ai-integration/
 layout: single
 author_profile: false
 service_schema: true
-excerpt: "Platform foundation services in Toronto and Canada for enterprise AI integration, runtime controls, APIs, observability, and AI-ready execution."
+excerpt: "Platform foundation services in Toronto and across Canada. Umplify designs the Azure runtime, APIs, observability, and access layers that let enterprise AI run safely with real systems."
 header:
   overlay_color: "#08142C"
   overlay_filter: "0.20"
@@ -17,18 +17,42 @@ header:
 
 Enterprise AI needs more than access to a model. It needs dependable APIs, observability, access layers, runtime controls, and integration patterns that let AI operate safely with real systems and workflows.
 
-Umplify helps businesses create those platform foundations so AI becomes a usable enterprise capability rather than a fragile experiment layered onto the stack.
+Umplify helps businesses create those platform foundations on Azure so AI becomes a usable enterprise capability rather than a fragile experiment layered onto the stack.
 
 ## What this service covers
 
-- runtime and access-layer thinking for AI systems
-- API and context delivery foundations
-- observability and control considerations
-- platform support for AI-enabled workflows
-- architectural readiness for enterprise-scale execution
+- Runtime and access-layer design for AI systems
+- API and context delivery foundations (API Management, OpenAPI, gateway patterns)
+- Observability and control (Application Insights, Log Analytics, dashboards, cost guardrails)
+- Identity and audit (Entra ID, managed identities, audit logging)
+- Network isolation and private connectivity (Private Link, VNet integration, customer-managed keys)
+- Architectural readiness for enterprise-scale execution
+
+## What you get
+
+- A platform reference architecture aligned to your existing Azure tenant
+- API and access-layer patterns ready for AI workloads
+- Observability and cost guardrails so AI cost stays predictable
+- Identity, audit, and network design that satisfies security review
+- Skills transferred to your platform team
+
+## Why it matters
+
+The platform underneath AI is what makes AI dependable. Without it, every model upgrade and every new use case becomes another integration project.
+
+## Why Umplify
+
+Senior architects and engineers with production experience designing Azure platforms that carry AI workloads alongside the rest of the enterprise stack.
+
+## Ready to design the foundation?
+
+[Book a free discovery call](/contact/){: .btn .btn--primary .btn--large}
+[How we engage](/how-we-engage/){: .btn .btn--inverse}
 
 ## Related pages
 
 - [Enterprise AI Integration Services](/enterprise-ai-integration/)
-- [Cloud Platform Engineering Services](/cloud-solutions/)
+- [Azure Cloud Platform Engineering Services](/cloud-solutions/)
+- [Private Knowledge and Secure Execution](/private-knowledge-secure-execution/)
+- [Infrastructure as Code and DevOps](/infrastructure-as-code-devops/)
 - [Contact Umplify](/contact/)

--- a/_pages/private-knowledge-secure-execution.md
+++ b/_pages/private-knowledge-secure-execution.md
@@ -4,7 +4,7 @@ permalink: /private-knowledge-secure-execution/
 layout: single
 author_profile: false
 service_schema: true
-excerpt: "Private knowledge and secure execution services in Toronto and Canada for organizations that want AI to use internal context safely and effectively."
+excerpt: "Private knowledge and secure execution services in Toronto and across Canada. Umplify designs permission-aware retrieval and controlled execution so AI can use internal context without compromising trust."
 header:
   overlay_color: "#08142C"
   overlay_filter: "0.22"
@@ -15,24 +15,43 @@ header:
 
 ## Private knowledge and secure execution
 
-AI often underperforms because it has weak access to the context that actually matters. High-value answers and actions depend on private documents, internal process knowledge, permissions-aware retrieval, and clearer execution boundaries.
+AI often underperforms because it has weak access to the context that actually matters. High-value answers and actions depend on private documents, internal process knowledge, permission-aware retrieval, and clearer execution boundaries.
 
-Umplify helps organizations structure private knowledge access so AI can work with internal context responsibly. The objective is stronger usefulness without sacrificing trust, control, or security discipline.
+Umplify helps organizations structure private knowledge access so AI can work with internal context responsibly. The goal is stronger usefulness without sacrificing trust, control, or security discipline. Sensitive data stays inside your Azure tenant.
 
 ## What this service covers
 
-- internal knowledge access patterns
-- permission-aware retrieval design
-- controlled execution boundaries
-- higher-value answer and action design
-- trust and control considerations for business-critical workflows
+- Internal knowledge access patterns (SharePoint, OneDrive, Confluence, internal wikis, file shares, line-of-business apps)
+- Permission-aware retrieval design aligned to your identity model
+- Controlled execution boundaries and human-in-the-loop checkpoints
+- Higher-value answer and action design grounded in authoritative sources
+- Trust, audit, and control considerations for business-critical workflows
+- Azure-native architecture (Azure AI Search, Azure OpenAI, Entra ID, Private Link, customer-managed keys)
+
+## What you get
+
+- A retrieval architecture aligned to your existing identity and content stack
+- A reference implementation pattern on Azure with private networking and audit logging
+- Evaluation hooks so retrieval quality and answer quality can be measured
+- Documented governance posture you can share with security and compliance
+- A delivery plan with phases, dependencies, and risk areas
 
 ## Why it matters
 
-This is one of the clearest distinctions between superficial AI and enterprise-useful AI.
+This is one of the clearest distinctions between superficial AI and enterprise-useful AI. Private knowledge done well is what turns generic models into trusted internal tools.
+
+## Why Umplify
+
+Senior engineers and architects who design AI integration with security, identity, and governance as first-class concerns, not afterthoughts.
+
+## Ready to design secure access?
+
+[Book a free discovery call](/contact/){: .btn .btn--primary .btn--large}
+[How we engage](/how-we-engage/){: .btn .btn--inverse}
 
 ## Related pages
 
 - [AI Governance and Productionization](/ai-governance-productionization/)
 - [Enterprise AI Integration](/enterprise-ai-integration/)
+- [Platform Foundations for AI Integration](/platform-foundations-ai-integration/)
 - [Contact Umplify](/contact/)

--- a/_pages/saas-platform-architecture.md
+++ b/_pages/saas-platform-architecture.md
@@ -4,11 +4,13 @@ permalink: /saas-platform-architecture/
 layout: single
 author_profile: false
 service_schema: true
-excerpt: "SaaS and platform architecture services in Toronto and Canada for products that need stronger tenancy, extensibility, reliability, and operational scale."
+excerpt: "SaaS and platform architecture services in Toronto and across Canada. Umplify designs stronger tenancy, extensibility, reliability, and operational scale for SaaS products on Azure."
 header:
   overlay_color: "#08142C"
   overlay_filter: "0.20"
   overlay_image: /assets/images/revamp/hero-cloud.svg
+redirect_from:
+  - /cloud-solutions/saas-transformation/
 ---
 
 ![Platform architecture visual](/assets/images/revamp/platform-architecture.svg)
@@ -17,18 +19,42 @@ header:
 
 Strong platforms create leverage across product, operations, and delivery. We help businesses shape stronger SaaS and platform foundations with better tenancy models, clearer system boundaries, stronger reliability, and a more extensible architecture.
 
-The value is not only technical. It creates better readiness for scale, faster product evolution, and a cleaner foundation for AI-enabled capabilities over time.
+The value is not only technical. It creates better readiness for scale, faster product evolution, predictable unit economics, and a cleaner foundation for AI-enabled capabilities over time.
 
 ## What this service covers
 
-- SaaS evolution and tenancy design
-- platform boundary and reliability design
-- extensibility and integration thinking
-- operational efficiency improvements
-- architecture choices aligned to product scale
+- SaaS evolution and tenancy design (silo, pool, bridge, and hybrid models)
+- Platform boundary and reliability design
+- Identity, billing, and entitlements patterns
+- Extensibility and integration thinking (APIs, webhooks, MCP-oriented patterns)
+- Operational efficiency, cost predictability, and unit economics
+- Architecture choices aligned to product scale and stage
+
+## What you get
+
+- A tenancy and platform architecture aligned to your product roadmap
+- A delivery plan with phases, dependencies, and risk areas
+- Reference patterns on Azure (App Service, AKS, Container Apps, API Management, Cosmos DB, Azure SQL)
+- Cost and capacity framing that survives growth
+- Skills transferred to your engineering team along the way
+
+## Why it matters
+
+The shape of your SaaS platform determines what your product can become. Stronger boundaries, cleaner tenancy, and better extensibility are how SaaS businesses turn into platforms.
+
+## Why Umplify
+
+Senior engineers and architects who have shipped SaaS platforms on Azure. We design for the next two years of product evolution, not just today's release.
+
+## Ready to evolve your platform?
+
+[Book a free discovery call](/contact/){: .btn .btn--primary .btn--large}
+[How we engage](/how-we-engage/){: .btn .btn--inverse}
 
 ## Related pages
 
 - [Cloud Modernization Services](/cloud-modernization/)
+- [Web Applications and APIs](/web-applications-apis/)
 - [Infrastructure as Code and DevOps](/infrastructure-as-code-devops/)
+- [Platform Foundations for AI Integration](/platform-foundations-ai-integration/)
 - [Contact Umplify](/contact/)

--- a/_pages/saas-transformation.md
+++ b/_pages/saas-transformation.md
@@ -1,30 +1,6 @@
 ---
-title: "Saas Transformation"
-sitemap: false
-layout: splash
+title: "SaaS Transformation"
 permalink: /cloud-solutions/saas-transformation/
-
-feature_row_left:
-  - image_path: /assets/images/splash/transform.svg
-    title: SaaS Transformation
-    excerpt: Startups, Independent Software Vendors, and large enterprises are employing cloud infrastructure to make their products available 24/7, fault-tolerant, secure, and scalable as their businesses grow. This technological demand dictates modernizing applications' architecture to adapt models like Platform-as-a-Service (Paas), Software-as-a-Service (SaaS), or Infrastructure-as-a-Service (IaaS). With the evolving cloud technologies, our team has enough expertise to seamlessly steer your business through all possible challenges. Should you wish to transform your SaaS application to Azure Cloud, our team is ready to help you to implement a solid strategy for a successful SaaS transformation.
+sitemap: false
+redirect_to: /saas-platform-architecture/
 ---
-
-{% include feature_row id="feature_row_left" type="left" %}
-
-
-## Assessment
-
-We start our engagement by learning about your company's business model, the application's users and tenants, licensing model, customer support, your roadmap, and the milestones. We will also thoroughly analyze your application's architecture, code, database, continuous delivery, and security to understand your application's state and offering.
-
-## Implementing success strategy
-
-Offering a SaaS application implies the need for high availability, multi-tenancy, user management, licensing, traffic resilience, greater security, and seamless upgrades. We will make the necessary recommendations based on Azure Cloud's components and services to optimize your SaaS application's architecture, code quality, continuous integration and delivery, security, and fail-over support.
-
-## Presentation
-
-We present our recommendations during a meeting to discuss our strategy for putting a sustainable infrastructure and application architecture in place. We will highlight the construction phase's necessary tools, code release, and branching strategies, Azure Cloud components to utilize, associated costs, the extent of scalability and resilience, DevOps, and automation to deploy the application to multiple environments like Dev, Test, UAT and production.
-
-## Implementation
-
-Implementing and developing cloud applications is our critical service to our clients. We will partner with your company to implement your cloud application in-house at Umplify, or to extend your development team by embedding our resources into it to commence the construction phase. Should you wish to employ our strategy in SaaS transformation only, the presentation phase will conclude our engagement while we are always available for further consultation and solution augmentation.

--- a/_pages/serverless-event-driven-systems.md
+++ b/_pages/serverless-event-driven-systems.md
@@ -4,11 +4,13 @@ permalink: /serverless-event-driven-systems/
 layout: single
 author_profile: false
 service_schema: true
-excerpt: "Serverless and event-driven systems services in Toronto and Canada for workloads that benefit from elasticity, clean integration, and lower operational drag."
+excerpt: "Serverless and event-driven systems services in Toronto and across Canada. Umplify designs Azure-native event-driven architectures for elasticity, clean integration, and lower operational drag."
 header:
   overlay_color: "#08142C"
   overlay_filter: "0.20"
   overlay_image: /assets/images/revamp/hero-cloud.svg
+redirect_from:
+  - /cloud-solutions/serverless-web-apps/
 ---
 
 ![Serverless systems visual](/assets/images/revamp/serverless-event.svg)
@@ -17,18 +19,42 @@ header:
 
 Event-driven and serverless patterns can create real advantages when the workload fits the model. They can improve responsiveness, reduce unnecessary infrastructure management, and simplify the way systems react to change and integrate with workflows.
 
-Umplify helps teams decide where these patterns make sense, how they should be structured, and how they can support modern products and AI-enabled orchestration without creating architectural sprawl.
+Umplify helps teams decide where these patterns make sense, how they should be structured, and how they can support modern products and AI-enabled orchestration without creating architectural sprawl. We are equally comfortable saying yes or no to serverless on a given workload.
 
 ## What this service covers
 
-- event-driven architecture guidance
-- serverless workload design
-- orchestration and integration considerations
-- fit analysis for workload types
-- practical implementation framing
+- Event-driven architecture guidance (Service Bus, Event Grid, Event Hubs)
+- Serverless workload design (Functions, Container Apps, Logic Apps)
+- Orchestration and integration patterns
+- Fit analysis and trade-off framing for workload types
+- Cold-start, cost, observability, and reliability considerations
+- Practical implementation framing on Azure
+
+## What you get
+
+- A workload-by-workload recommendation: serverless, container, or service
+- A reference event-driven architecture aligned to your domain
+- Reliability, observability, and cost design
+- Infrastructure-as-code (Bicep or Terraform) you can review and own
+- Skills transferred to your engineering team along the way
+
+## Why it matters
+
+The wrong serverless decision creates hidden cost and operational pain. The right one removes whole categories of work. We help teams pick correctly, then implement cleanly.
+
+## Why Umplify
+
+Senior architects and engineers with production experience designing event-driven and serverless workloads on Azure for high-throughput, AI-enabled, and integration-heavy systems.
+
+## Ready to scope a workload?
+
+[Book a free discovery call](/contact/){: .btn .btn--primary .btn--large}
+[How we engage](/how-we-engage/){: .btn .btn--inverse}
 
 ## Related pages
 
-- [Cloud Platform Engineering Services](/cloud-solutions/)
+- [Azure Cloud Platform Engineering Services](/cloud-solutions/)
 - [Platform Foundations for AI Integration](/platform-foundations-ai-integration/)
+- [Web Applications and APIs](/web-applications-apis/)
+- [Infrastructure as Code and DevOps](/infrastructure-as-code-devops/)
 - [Contact Umplify](/contact/)

--- a/_pages/serverless-web-apps.md
+++ b/_pages/serverless-web-apps.md
@@ -1,30 +1,6 @@
 ---
-title: "Azure Cloud Enrollment"
-sitemap: false
-layout: splash
+title: "Serverless Web Apps"
 permalink: /cloud-solutions/serverless-web-apps/
-
-feature_row_left:
-  - image_path: /assets/images/splash/webapps.svg
-    title: Serverless Web Apps
-    excerpt: Startups, Independent Software Vendors, and large enterprises are employing cloud infrastructure to make their products available 24/7, fault-tolerant, secure, and scalable as their businesses grow. This technological demand dictates modernizing applications' architecture to adapt models like Platform-as-a-Service (Paas), Software-as-a-Service (SaaS), or Infrastructure-as-a-Service (IaaS). With the evolving cloud technologies, our team has enough expertise to seamlessly steer your business through all possible challenges. We have tailored this solution to help companies consider adopting serverless architecture for their new or existing web apps like RESTful Web APIs.
+sitemap: false
+redirect_to: /serverless-event-driven-systems/
 ---
-
-{% include feature_row id="feature_row_left" type="left" %}
-
-
-## Assessment
-
-Our senior developers and architects are experts in the Microsoft Azure Cloud technology and harness its powerful platform to transform your business with cloud-native application modernization. We have architectured many enterprise applications using the most advanced and cutting-edge cloud technologies. We engage our subject-matter experts with your key team members to review and understand your web app and document your current status and ultimate goal. We also consider key requirements in this phase, including security, application architecture, caching, user traffic, infrastructure, DevOps, and the allocated budget.
-
-## Implementing success strategy
-
-We leverage a team of unparalleled architects and star developers at Umplify. Following the assessment phase, this team dives into analyzing the collected data and information. It discusses the requirements to develop sustainable, scalable, and modern serverless solutions for your web app. Should further consultation, idea verification, and clarification become necessary, we will reach out to seek your team's input during this phase.
-
-## Presentation
-
-We present our recommendations during a meeting to discuss our strategy for putting a sustainable infrastructure and application architecture in place. We will highlight the construction phase's necessary tools, code release, and branching strategies, Azure Cloud components to utilize, associated costs, the extent of scalability and resilience, DevOps, and automation to deploy the application to multiple environments like Dev, Test, UAT and production. We will also show you the advantages of a serverless web app, making stateful data available in such web apps, resiliency, and availability.
-
-## Implementation
-
-Implementing and developing cloud applications is our critical service to our clients. We will partner with your company to implement your cloud application in-house at Umplify, or to extend your development team by embedding our resources into it to commence the construction phase. Should you wish to employ our serverless strategy, the presentation phase will conclude our engagement while we are always available for further consultation and solution augmentation.

--- a/_pages/web-applications-apis.md
+++ b/_pages/web-applications-apis.md
@@ -4,7 +4,7 @@ permalink: /web-applications-apis/
 layout: single
 author_profile: false
 service_schema: true
-excerpt: "Web applications and API modernization services in Toronto and Canada for systems that need stronger performance, integration design, and readiness for AI-enabled workflows."
+excerpt: "Web applications and API modernization services in Toronto and across Canada. Umplify modernizes .NET applications and APIs for stronger performance, integration design, and readiness for AI-enabled workflows."
 header:
   overlay_color: "#08142C"
   overlay_filter: "0.20"
@@ -17,18 +17,42 @@ header:
 
 Modern web applications and APIs need more than surface-level refreshes. They need clearer boundaries, stronger performance, more durable integration design, and an engineering model that supports ongoing change.
 
-Umplify helps businesses modernize application layers so they are easier to maintain, easier to integrate, and better positioned for AI-enabled workflows, internal tools, and future product evolution.
+Umplify helps businesses modernize application layers so they are easier to maintain, easier to integrate, and better positioned for AI-enabled workflows, internal tools, and future product evolution. Our work is .NET-deep and Azure-native.
 
 ## What this service covers
 
-- web application modernization direction
-- API design and integration improvement
-- performance and maintainability priorities
-- architecture alignment for future workflows
-- readiness for internal and external connectivity
+- Web application modernization (Angular, React, Blazor, ASP.NET Core)
+- API design and integration improvement (REST, GraphQL, gRPC)
+- Performance, caching, and resiliency patterns
+- Authentication and authorization (Entra ID, OAuth 2.0, OpenID Connect)
+- API gateway and management with Azure API Management
+- Architecture alignment for AI-enabled features and integrations
+
+## What you get
+
+- A modernization plan with staged delivery and rollback framing
+- API designs ready for internal and external consumers
+- Performance and reliability patterns suitable for production traffic
+- CI/CD and infrastructure-as-code so releases stay safe
+- Skills transferred to your engineering team along the way
+
+## Why it matters
+
+Strong APIs and clean web applications are the surface where AI integrations meet your product. Get the surface right and AI features ship faster, more safely, and with less rework later.
+
+## Why Umplify
+
+Two decades of senior .NET and front-end engineering depth, with Azure-native API and web app delivery experience across enterprise and ISV settings.
+
+## Ready to modernize?
+
+[Book a free discovery call](/contact/){: .btn .btn--primary .btn--large}
+[How we engage](/how-we-engage/){: .btn .btn--inverse}
 
 ## Related pages
 
 - [Cloud Modernization Services](/cloud-modernization/)
 - [Enterprise AI Integration Services](/enterprise-ai-integration/)
+- [SaaS and Platform Architecture](/saas-platform-architecture/)
+- [Infrastructure as Code and DevOps](/infrastructure-as-code-devops/)
 - [Contact Umplify](/contact/)

--- a/_pages/what-umplify-offers.md
+++ b/_pages/what-umplify-offers.md
@@ -1,36 +1,6 @@
 ---
-title: "What we offer"
-sitemap: false
-layout: splash
+title: "What Umplify Offers"
 permalink: /what-umplify-offers/
-
-feature_row_left:
-  - image_path: /assets/images/splash/what-we-offer.svg
-    title: What we offer
-    excerpt: Startups, Independent Software Vendors, and large enterprises are employing cloud infrastructure to make their products available 24/7, fault-tolerant, secure, and scalable as their businesses grow. This technological demand dictates modernizing applications' architecture to adapt models like Platform-as-a-Service (Paas), Software-as-a-Service (SaaS), or Infrastructure-as-a-Service (IaaS). With the evolving cloud technologies, our team has enough expertise to seamlessly steer your business through all possible challenges.
-
-feature_row:
-  - title: Securing applications
-    excerpt: We leverage an array of security tools available on Microsoft Azure to secure your software and its infrastructure to ensure your users are authentic and they are the ones who are supposed to access your platform. We also provide tools and solutions to store and retrieve your data on cloud infrastructure securely.
-    image_path: /assets/images/splash/security.svg
-  - title: Building scalable Microservices
-    excerpt: We possess the knowledge of refactoring and modernizing the architecture of legacy applications to more efficient and cloud-powered microservices. We leverage event-driven technologies, serverless architecture, and app services to get your applications' tiers hosted on the cloud.
-    image_path: /assets/images/splash/microservice.svg
-  - title: Saving operating costs
-    excerpt: Our approach ensures your application is resilient to traffic spikes, highly available, and consumes resources only when needed. Therefore, the cost of hosting and operating your application becomes minimal when there is no demand.
-    image_path: /assets/images/splash/savingcosts.svg
-  - title: Redundancy and autoscaling
-    excerpt: We employ contemporary technologies like [Docker](https://docker.com) to containerize your applications, [Kubernetes](https://kubernetes.io), or [Microsoft Container Apps](https://azure.microsoft.com/en-us/services/container-apps/) to fully manage and orchestrate them to ensure redundancy and high-availability is in place. This approach eliminates downtimes for mission-critical applications even when upgrading the code.
-    image_path: /assets/images/splash/autoscaling.svg
-  - title: Real-time applications
-    excerpt: We can offer cloud-based serverless solutions for your real-time application like chat applications or IoT devices to guarantee communication at blazing speed and instant. This real-time communication can be on the UI side of the application or between the backend infrastructure's tiers.
-    image_path: /assets/images/splash/realtime.svg
-  - title: Content Delivery Network
-    excerpt: If you wish your static web app to be as close as possible to your end users to experience minimal latency, we help your team continuously deploy your UI apps to Azure cloud-powered CDN by CI/CD pipelines. 
-    image_path: /assets/images/splash/cdn.svg
+sitemap: false
+redirect_to: /cloud-solutions/
 ---
-
-{% include feature_row id="feature_row_left" type="left" %}
-
-
-{% include feature_row %}


### PR DESCRIPTION
Add CLAUDE.md (editor/designer guide) and make broad content, navigation, and SEO updates to emphasise Azure, production-readiness, and North American audience. Changes include: update _config.yml (title, subtitle, description, add jekyll-redirect-from), adjust top nav (rename Cloud Platform to Azure Platform, add How We Engage), enhance JSON-LD in _includes/head/custom.html (organization fields, contactPoints, areaServed, knowsAbout and conditional Service schema), set service_schema on relevant landing pages, create /how-we-engage/ page, add redirect_to for azure-cloud-enrollment -> cloud-modernization, refactor 404 and contact pages, and refresh numerous service pages to strengthen Azure-native messaging, CTAs, related links, and production-focused content. These edits improve SEO, structured data, clarity of offerings, CTAs, and site navigation.

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

<!-- This is a bug fix. -->
<!-- This is an enhancement or feature. -->
<!-- This is a documentation change. -->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

## Context

<!--
  Is this related to any GitHub issue(s)?
-->

<!--
  Please confirm that you want to submit this Pull Request to Minimal Mistakes, the free Jekyll theme by Michael Rose, by deleting this comment block.
-->
